### PR TITLE
Enable automatic PyPI publishing in GitHub Actions workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,8 +25,8 @@ jobs:
           python -m pip install build setuptools>=61.2 wheel
           python -m build --no-isolation
 
-#      - name: Publish package
-#        uses: pypa/gh-action-pypi-publish@release/v1
-#        with:
-#          user: __token__
-#          password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
**Summary**

1. Previously created a GitHub release with the publish step commented out to verify that the package builds correctly.
2. Now updated `publish.yml` by uncommenting the Publish package step, so that future releases will automatically upload the package to PyPI.
3. Ensures that the first official release (`25.09.01`) can be published directly from GitHub Actions.