### PR TITLE
Set version to 25.09.02 and update publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,3 @@ jobs:
 
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fwl-zalmoxis"
-version = "25.09.01"
+version = "25.09.02"
 description = "Zalmoxis (Planetary interior structure model)"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/zalmoxis/__init__.py
+++ b/src/zalmoxis/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "25.09.01"
+__version__ = "25.09.02"


### PR DESCRIPTION
In this PR, I removed the authentication step (user & password) from the `publish.yml` workflow and switched to Trusted Publishing. I ran into authentication issues with the API token approach when I was making the GitHub release, so I updated the configuration and added the Zalmoxis repository as a trusted publisher on PyPI. With this change, future GitHub releases should automatically trigger package uploads without requiring an API token.