### PR TITLE
Add CODEOWNERS file to assign PROTEUS Maintainer team for PR reviews

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,0 +1,5 @@
+# Tutorial:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# The PROTEUS Maintainer team will automatically be assigned to review each PR to main.
+* @FormingWorlds/proteus-maintainer

--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -3,3 +3,4 @@
 
 # The PROTEUS Maintainer team will automatically be assigned to review each PR to main.
 * @FormingWorlds/proteus-maintainer
+* @FormingWorlds/zalmoxis-maintainers


### PR DESCRIPTION
This PR adds CODEOWNERS file to assign PROTEUS Maintainer team for PR reviews