### PR TITLE
Add adiabatic temperature mode using native dT/dP tables

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,9 +22,9 @@ Initial guesses and assumptions for the planetary structure.
 |---|---|---|---|
 | `core_mass_fraction` | float | -- | Core mass as a fraction of total mass. Also used in the Seager et al. (2007) scaling relation for the initial radius guess. Earth: ~0.325. |
 | `mantle_mass_fraction` | float | -- | Mantle mass as a fraction of total mass. Set to 0 for a 2-layer model where the mantle fills the remainder (1 - `core_mass_fraction`). Must be > 0 when using a 3-layer model with an ice layer. |
-| `temperature_mode` | string | -- | Temperature profile type. One of: `"isothermal"`, `"linear"`, `"prescribed"`. See [Temperature profiles](#temperature-profiles). |
-| `surface_temperature` | float | K | Surface temperature. Used when `temperature_mode` is `"isothermal"` or `"linear"`. |
-| `center_temperature` | float | K | Central temperature. Used when `temperature_mode` is `"linear"`. |
+| `temperature_mode` | string | -- | Temperature profile type. One of: `"isothermal"`, `"linear"`, `"prescribed"`, `"adiabatic"`. See [Temperature profiles](#temperature-profiles). |
+| `surface_temperature` | float | K | Surface temperature. Used when `temperature_mode` is `"isothermal"`, `"linear"`, or `"adiabatic"`. |
+| `center_temperature` | float | K | Central temperature. Used when `temperature_mode` is `"linear"` or `"adiabatic"` (initial guess). |
 | `temperature_profile_file` | string | -- | Filename (relative to `input/`) containing a prescribed radial temperature profile. Used when `temperature_mode` is `"prescribed"`. |
 
 #### Temperature profiles
@@ -34,6 +34,7 @@ Temperature profiles are only relevant when using a temperature-dependent EOS (i
 - **`"isothermal"`**: Constant temperature equal to `surface_temperature` at all radii.
 - **`"linear"`**: Linear interpolation from `center_temperature` at $r = 0$ to `surface_temperature` at $r = R$.
 - **`"prescribed"`**: Reads a temperature profile from `temperature_profile_file`. The file must contain one temperature value per line (in K), ordered from center to surface, with the same number of entries as `num_layers`.
+- **`"adiabatic"`**: Computes the adiabatic temperature profile by integrating pre-tabulated $(dT/dP)_S$ gradients from the EOS, starting at `surface_temperature` and integrating inward. The initial guess is a linear profile between `surface_temperature` and `center_temperature`. **Only available for T-dependent EOS** (`WolfBower2018:MgSiO3` or `RTPress100TPa:MgSiO3`) that provide native adiabat gradient tables. For T-independent EOS layers (e.g., `Seager2007:iron` core), temperature is held constant (isothermal) through that layer.
 
 ---
 
@@ -281,7 +282,6 @@ See the [model documentation](model.md#pressure-solver-brents-method) for detail
 | `target_surface_pressure` | float | Pa | 101325 | Target pressure at the planetary surface. Default is 1 atm. |
 | `pressure_tolerance` | float | Pa | 1e9 | Convergence criterion: the solver iterates until $\lvert P_\mathrm{surface} - P_\mathrm{target} \rvert$ falls below this value. |
 | `max_iterations_pressure` | int | -- | 200 | Maximum number of function evaluations for the Brent solver. Typical convergence requires 20--36 evaluations. |
-| `pressure_adjustment_factor` | float | -- | 1.1 | **Deprecated.** Retained for backward compatibility. The Brent solver does not use this parameter. |
 
 ---
 

--- a/docs/data.md
+++ b/docs/data.md
@@ -24,7 +24,9 @@ The table below lists every data file used by Zalmoxis, organised by subdirector
 | `eos_seager07_water.txt` | `data/EOS_Seager2007/` | CSV (rho in g/cm^3, P in GPa) | [Seager et al. (2007)](https://iopscience.iop.org/article/10.1086/521346) | Water ice VII pressure-density EOS |
 | `density_melt.dat` | `data/EOS_WolfBower2018_1TPa/` | TSV (P in Pa, T in K, rho in kg/m^3) | [Wolf & Bower (2018)](https://doi.org/10.1016/j.pepi.2018.02.004) | MgSiO3 melt density EOS (P: 0--1 TPa, T: 0--16500 K). Out-of-bounds pressures are clamped to the table edge. |
 | `density_solid.dat` | `data/EOS_WolfBower2018_1TPa/` | TSV (P in Pa, T in K, rho in kg/m^3) | [Wolf & Bower (2018)](https://doi.org/10.1016/j.pepi.2018.02.004) | MgSiO3 solid (bridgmanite) density EOS, derived from [Mosenfelder et al. (2009)](https://doi.org/10.1029/2008JB005900) (P: 0--1 TPa, T: 0--16500 K). Out-of-bounds pressures are clamped to the table edge. |
+| `adiabat_temp_grad_melt.dat` | `data/EOS_WolfBower2018_1TPa/` | TSV (P in Pa, T in K, dT/dP in K/Pa) | [Wolf & Bower (2018)](https://doi.org/10.1016/j.pepi.2018.02.004) | MgSiO3 melt adiabatic temperature gradient $(dT/dP)_S$ (P: 0--1 TPa, T: 0--16500 K). Used for `"adiabatic"` temperature mode. |
 | `density_melt.dat` | `data/EOS_RTPress_melt_100TPa/` | TSV (P in Pa, T in K, rho in kg/m^3) | Extended RTpress melt table | MgSiO3 melt density EOS extended to 100 TPa (P: 1e3--1e14 Pa, T: 400--50000 K). Used by `RTPress100TPa:MgSiO3`. Solid phase uses the WolfBower2018 table above. |
+| `adiabat_temp_grad_melt.dat` | `data/EOS_RTPress_melt_100TPa/` | TSV (P in Pa, T in K, dT/dP in K/Pa) | Extended RTpress melt table | MgSiO3 melt adiabatic temperature gradient $(dT/dP)_S$ extended to 100 TPa (P: 1e3--1e14 Pa, T: 400--50000 K). Used for `"adiabatic"` temperature mode with `RTPress100TPa:MgSiO3`. |
 
 ### Melting curves
 

--- a/docs/data.md
+++ b/docs/data.md
@@ -40,7 +40,10 @@ The table below lists every data file used by Zalmoxis, organised by subdirector
 | File | Location | Format | Source | Description |
 |------|----------|--------|--------|-------------|
 | `massradiusEarthlikeRocky.txt` | `data/mass_radius_curves/` | Space-separated (M in M_Earth, R in R_Earth) | [Zeng et al. (2019)](https://lweb.cfa.harvard.edu/~lzeng/planetmodels.html) | Earth-like rocky M-R curve (32.5% Fe + 67.5% MgSiO3) |
+| `massradiusFe.txt` | `data/mass_radius_curves/` | Space-separated (M in M_Earth, R in R_Earth) | [Zeng et al. (2019)](https://lweb.cfa.harvard.edu/~lzeng/planetmodels.html) | Pure iron M-R curve |
+| `massradiusmgsio3.txt` | `data/mass_radius_curves/` | Space-separated (M in M_Earth, R in R_Earth) | [Zeng et al. (2019)](https://lweb.cfa.harvard.edu/~lzeng/planetmodels.html) | Pure MgSiO3 M-R curve |
 | `massradius_50percentH2O_300K_1mbar.txt` | `data/mass_radius_curves/` | Space-separated (M in M_Earth, R in R_Earth) | [Zeng et al. (2019)](https://lweb.cfa.harvard.edu/~lzeng/planetmodels.html) | 50% H2O + 50% rocky M-R curve (300 K, 1 mbar surface) |
+| `massradius_100percentH2O_300K_1mbar.txt` | `data/mass_radius_curves/` | Space-separated (M in M_Earth, R in R_Earth) | [Zeng et al. (2019)](https://lweb.cfa.harvard.edu/~lzeng/planetmodels.html) | Pure H2O M-R curve (300 K, 1 mbar surface) |
 
 ### Radial profiles (validation benchmarks)
 

--- a/docs/model.md
+++ b/docs/model.md
@@ -103,7 +103,7 @@ $$
 $$
 
 This EOS is appropriate when modeling hot rocky planets whose mantles may be partially or fully molten, which is critical for accurately coupling to thermal evolution codes.
-A temperature profile (isothermal, linear, or prescribed from file) must be supplied.
+A temperature profile (isothermal, linear, prescribed from file, or adiabatic) must be supplied.
 When this EOS is selected for any layer, the radial integration is split into two segments (controlled by `adaptive_radial_fraction`) to handle the steep density gradients near the surface.
 
 **Mass limit.** The WolfBower2018 tables cover pressures up to ~1 TPa.
@@ -347,7 +347,9 @@ post_processing() ──► output files + plots
 - **`get_Tdep_density()`** (`eos_functions.py`): Computes mantle density accounting for temperature-dependent phase transitions using the solidus/liquidus melting curves and volume-additive mixing in the mush regime.
   Guards against `None` returns from out-of-bounds table lookups.
 
-- **`calculate_temperature_profile()`** (`eos_functions.py`): Returns a callable $T(r)$ for three modes: `"isothermal"` (uniform), `"linear"` (center-to-surface gradient), or `"prescribed"` (loaded from file).
+- **`calculate_temperature_profile()`** (`eos_functions.py`): Returns a callable $T(r)$ for four modes: `"isothermal"` (uniform), `"linear"` (center-to-surface gradient), `"prescribed"` (loaded from file), or `"adiabatic"` (returns a linear initial guess; the self-consistent adiabat is computed later by `compute_adiabatic_temperature()`).
+
+- **`compute_adiabatic_temperature()`** (`eos_functions.py`): Computes the adiabatic temperature profile $T(r)$ by integrating pre-tabulated $(dT/dP)_S$ gradients from the EOS. Starting at `surface_temperature`, it integrates inward shell-by-shell: $T_{i} = T_{i+1} + (dT/dP)_S \cdot \Delta P$. Only available for T-dependent EOS (`WolfBower2018:MgSiO3`, `RTPress100TPa:MgSiO3`) that provide native `adiabat_temp_grad_melt.dat` tables. For T-independent layers (e.g., the iron core), the temperature is held constant.
 
 - **`parse_eos_config()`** (`zalmoxis.py`): Parses the `[EOS]` TOML section into a per-layer dictionary.
   Handles both the new per-layer format and legacy global-string format via `LEGACY_EOS_MAP`.

--- a/input/default.toml
+++ b/input/default.toml
@@ -6,9 +6,9 @@ planet_mass                = 1 # Mass of the planet (in Earth masses = 5.972e24 
 [AssumptionsAndInitialGuesses]
 core_mass_fraction         = 0.325 # Initial guess for the core mass as a fraction of the total mass
 mantle_mass_fraction       = 0 # Initial guess for the mantle mass as a fraction of the total mass
-temperature_mode           = "linear" # Choice of input temperature profile: "isothermal", "linear", "prescribed"
-surface_temperature        = 3500 # Surface temperature (K), required for temperature_mode="isothermal" or "linear", ignored otherwise
-center_temperature         = 6000 # Central temperature (K), required for temperature_mode="linear", ignored otherwise
+temperature_mode           = "linear" # Choice of input temperature profile: "isothermal", "linear", "prescribed", "adiabatic"
+surface_temperature        = 3500 # Surface temperature (K), required for temperature_mode="isothermal", "linear", or "adiabatic", ignored otherwise
+center_temperature         = 6000 # Central temperature (K), required for temperature_mode="linear" or "adiabatic" (initial guess), ignored otherwise
 temperature_profile_file   = "temp_profile.txt" # Filename containing a prescribed temperature profile, required for temperature_mode="prescribed"
 
 [EOS]
@@ -17,8 +17,9 @@ temperature_profile_file   = "temp_profile.txt" # Filename containing a prescrib
 #   "Seager2007:iron"       - Seager+2007 tabulated Fe epsilon (300K)
 #   "Seager2007:MgSiO3"    - Seager+2007 tabulated MgSiO3 perovskite (300K)
 #   "Seager2007:H2O"       - Seager+2007 tabulated water ice (300K)
-#   "WolfBower2018:MgSiO3" - Wolf&Bower+2018 T-dependent MgSiO3 (melt/solid), limited to <= 7 M_earth
-#   "Analytic:<material>"  - Seager+2007 analytic polytrope (300K, no data needed)
+#   "WolfBower2018:MgSiO3"  - Wolf&Bower+2018 T-dependent MgSiO3 (melt/solid), limited to <= 7 M_earth
+#   "RTPress100TPa:MgSiO3"  - Extended RTpress MgSiO3 melt EOS (up to 100 TPa)
+#   "Analytic:<material>"   - Seager+2007 analytic polytrope (300K, no data needed)
 #     Valid analytic materials: iron, MgSiO3, MgFeSiO3, H2O, graphite, SiC
 core                       = "Seager2007:iron"
 mantle                     = "WolfBower2018:MgSiO3"
@@ -42,7 +43,6 @@ max_center_pressure_guess  = 10e12 # Maximum center pressure guess (Pa). Center 
 target_surface_pressure    = 101325 # Target surface pressure (Pa)
 pressure_tolerance         = 1e9 # Convergence tolerance for surface pressure convergence (Pa)
 max_iterations_pressure    = 200 # Maximum iterations for pressure adjustment loop
-pressure_adjustment_factor = 1.1 # Deprecated: retained for backward compatibility. The Brent solver does not use this parameter.
 
 [Output]
 data_enabled               = true # Flag to enable saving data to a file (true/false)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ develop = [
     "coverage[toml]",
     "pip-tools",
     "pytest >= 8.1",
+    "pytest-cov",
     "pre-commit",
     "ruff",
     "pytest-rich",

--- a/src/tests/test_adiabatic.py
+++ b/src/tests/test_adiabatic.py
@@ -148,12 +148,20 @@ class TestGetHeatCapacity:
 
     @staticmethod
     def _inject_cp_files(material_dicts, cp_melt_path, cp_solid_path):
-        """Add cp_file keys to the WolfBower2018 dict if not already present."""
-        mat_Tdep = material_dicts[1]
+        """Return a deep copy of material_dicts with cp_file keys added.
+
+        Uses deep copy to avoid mutating module-level globals returned
+        by ``load_material_dictionaries()``.
+        """
+        import copy
+
+        dicts = copy.deepcopy(material_dicts)
+        mat_Tdep = dicts[1]
         if 'cp_file' not in mat_Tdep.get('melted_mantle', {}):
             mat_Tdep['melted_mantle']['cp_file'] = str(cp_melt_path)
         if cp_solid_path.is_file() and 'cp_file' not in mat_Tdep.get('solid_mantle', {}):
             mat_Tdep['solid_mantle']['cp_file'] = str(cp_solid_path)
+        return dicts
 
     def test_positive_cp_for_melt_with_fwl_data(self):
         """Cp should be positive and physically reasonable for MgSiO3 melt.
@@ -169,7 +177,7 @@ class TestGetHeatCapacity:
         )
 
         material_dicts = load_material_dictionaries()
-        self._inject_cp_files(material_dicts, cp_melt, cp_solid)
+        material_dicts = self._inject_cp_files(material_dicts, cp_melt, cp_solid)
         layer_eos_config = {'core': 'Seager2007:iron', 'mantle': 'WolfBower2018:MgSiO3'}
         melting = load_solidus_liquidus_functions(layer_eos_config)
         solidus_func, liquidus_func = melting
@@ -202,7 +210,7 @@ class TestGetHeatCapacity:
         )
 
         material_dicts = load_material_dictionaries()
-        self._inject_cp_files(material_dicts, cp_melt, cp_solid)
+        material_dicts = self._inject_cp_files(material_dicts, cp_melt, cp_solid)
         layer_eos_config = {'core': 'Seager2007:iron', 'mantle': 'WolfBower2018:MgSiO3'}
         melting = load_solidus_liquidus_functions(layer_eos_config)
         solidus_func, liquidus_func = melting
@@ -237,7 +245,7 @@ class TestGetHeatCapacity:
         )
 
         material_dicts = load_material_dictionaries()
-        self._inject_cp_files(material_dicts, cp_melt, cp_solid)
+        material_dicts = self._inject_cp_files(material_dicts, cp_melt, cp_solid)
         layer_eos_config = {'core': 'Seager2007:iron', 'mantle': 'WolfBower2018:MgSiO3'}
         melting = load_solidus_liquidus_functions(layer_eos_config)
         solidus_func, liquidus_func = melting
@@ -293,7 +301,7 @@ class TestGetHeatCapacity:
         from zalmoxis.zalmoxis import load_material_dictionaries
 
         material_dicts = load_material_dictionaries()
-        self._inject_cp_files(material_dicts, cp_melt, cp_solid)
+        material_dicts = self._inject_cp_files(material_dicts, cp_melt, cp_solid)
 
         cp = get_heat_capacity(
             pressure=10e9,

--- a/src/tests/test_adiabatic.py
+++ b/src/tests/test_adiabatic.py
@@ -1,0 +1,227 @@
+"""Tests for adiabatic temperature mode.
+
+Tests cover:
+- Thermal expansivity computation via finite differences
+- Adiabatic temperature profile integration
+- Adiabatic mode in calculate_temperature_profile()
+
+References:
+    - docs/test_infrastructure.md
+    - docs/test_categorization.md
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from zalmoxis.eos_functions import (
+    calculate_temperature_profile,
+    compute_adiabatic_temperature,
+    compute_thermal_expansivity,
+)
+
+
+@pytest.mark.unit
+class TestComputeThermalExpansivity:
+    """Tests for compute_thermal_expansivity()."""
+
+    def test_positive_alpha_for_melt(self):
+        """Thermal expansivity should be positive for MgSiO3 melt at moderate P, T.
+
+        At 10 GPa and 3000 K, MgSiO3 melt has well-constrained EOS
+        with alpha ~ 1e-5 to 1e-4 1/K.
+        """
+        from zalmoxis.zalmoxis import (
+            load_material_dictionaries,
+            load_solidus_liquidus_functions,
+        )
+
+        material_dicts = load_material_dictionaries()
+        layer_eos_config = {'core': 'Seager2007:iron', 'mantle': 'WolfBower2018:MgSiO3'}
+        melting = load_solidus_liquidus_functions(layer_eos_config)
+        solidus_func, liquidus_func = melting
+
+        alpha = compute_thermal_expansivity(
+            pressure=10e9,
+            temperature=3000.0,
+            material_dictionaries=material_dicts,
+            layer_eos='WolfBower2018:MgSiO3',
+            solidus_func=solidus_func,
+            liquidus_func=liquidus_func,
+        )
+        assert alpha > 0, f'Expected positive alpha for MgSiO3 melt, got {alpha}'
+        # Typical values for silicate melts: 1e-5 to 5e-4 1/K
+        assert 1e-6 < alpha < 1e-3, f'Alpha {alpha} outside expected range'
+
+    def test_zero_alpha_for_T_independent_eos(self):
+        """Thermal expansivity should be zero for T-independent EOS (Seager2007 iron).
+
+        Seager2007 iron density depends only on pressure, so drho/dT = 0.
+        """
+        from zalmoxis.zalmoxis import load_material_dictionaries
+
+        material_dicts = load_material_dictionaries()
+
+        alpha = compute_thermal_expansivity(
+            pressure=100e9,
+            temperature=4000.0,
+            material_dictionaries=material_dicts,
+            layer_eos='Seager2007:iron',
+            solidus_func=None,
+            liquidus_func=None,
+        )
+        assert alpha == pytest.approx(0.0), (
+            f'Expected zero alpha for T-independent EOS, got {alpha}'
+        )
+
+
+@pytest.mark.unit
+class TestComputeAdiabaticTemperature:
+    """Tests for compute_adiabatic_temperature()."""
+
+    def test_surface_temperature_exact(self):
+        """T at the surface should equal surface_temperature exactly."""
+        n = 50
+        radii = np.linspace(0, 6.371e6, n)
+        pressure = np.linspace(360e9, 1e5, n)  # center to surface
+        gravity = np.full(n, 9.8)
+        mass_enclosed = np.linspace(0, 5.972e24, n)
+
+        T_surface = 3500.0
+        layer_eos_config = {'core': 'Seager2007:iron', 'mantle': 'Seager2007:MgSiO3'}
+        from zalmoxis.zalmoxis import load_material_dictionaries
+
+        material_dicts = load_material_dictionaries()
+
+        T = compute_adiabatic_temperature(
+            radii=radii,
+            pressure=pressure,
+            gravity=gravity,
+            mass_enclosed=mass_enclosed,
+            surface_temperature=T_surface,
+            Cp=1200.0,
+            cmb_mass=0.325 * 5.972e24,
+            core_mantle_mass=5.972e24,
+            layer_eos_config=layer_eos_config,
+            material_dictionaries=material_dicts,
+            solidus_func=None,
+            liquidus_func=None,
+        )
+        assert T[-1] == pytest.approx(T_surface), f'Surface temperature {T[-1]} != {T_surface}'
+
+    def test_isothermal_for_T_independent_eos(self):
+        """For a fully T-independent EOS planet, the adiabat should be isothermal.
+
+        When alpha = 0 everywhere, dT/dr = 0, so T(r) = T_surface.
+        """
+        n = 50
+        radii = np.linspace(0, 6.371e6, n)
+        pressure = np.linspace(360e9, 1e5, n)
+        gravity = np.full(n, 9.8)
+        mass_enclosed = np.linspace(0, 5.972e24, n)
+
+        T_surface = 3500.0
+        layer_eos_config = {'core': 'Seager2007:iron', 'mantle': 'Seager2007:MgSiO3'}
+        from zalmoxis.zalmoxis import load_material_dictionaries
+
+        material_dicts = load_material_dictionaries()
+
+        T = compute_adiabatic_temperature(
+            radii=radii,
+            pressure=pressure,
+            gravity=gravity,
+            mass_enclosed=mass_enclosed,
+            surface_temperature=T_surface,
+            Cp=1200.0,
+            cmb_mass=0.325 * 5.972e24,
+            core_mantle_mass=5.972e24,
+            layer_eos_config=layer_eos_config,
+            material_dictionaries=material_dicts,
+            solidus_func=None,
+            liquidus_func=None,
+        )
+        np.testing.assert_allclose(T, T_surface, rtol=1e-10)
+
+    def test_monotonic_increase_with_Tdep_eos(self):
+        """T should increase from surface toward center for a T-dependent mantle EOS.
+
+        The adiabatic gradient dT/dr = -alpha*g*T/Cp with alpha > 0, g > 0
+        means T increases inward (decreasing r).
+        """
+        from zalmoxis.zalmoxis import (
+            load_material_dictionaries,
+            load_solidus_liquidus_functions,
+        )
+
+        material_dicts = load_material_dictionaries()
+        layer_eos_config = {'core': 'Seager2007:iron', 'mantle': 'WolfBower2018:MgSiO3'}
+        melting = load_solidus_liquidus_functions(layer_eos_config)
+        solidus_func, liquidus_func = melting
+
+        n = 100
+        radii = np.linspace(0, 6.371e6, n)
+        pressure = np.linspace(360e9, 1e5, n)
+        gravity = np.linspace(0, 9.8, n)
+        mass_enclosed = np.linspace(0, 5.972e24, n)
+
+        T = compute_adiabatic_temperature(
+            radii=radii,
+            pressure=pressure,
+            gravity=gravity,
+            mass_enclosed=mass_enclosed,
+            surface_temperature=3500.0,
+            Cp=1200.0,
+            cmb_mass=0.325 * 5.972e24,
+            core_mantle_mass=5.972e24,
+            layer_eos_config=layer_eos_config,
+            material_dictionaries=material_dicts,
+            solidus_func=solidus_func,
+            liquidus_func=liquidus_func,
+        )
+        # In the mantle (T-dependent EOS), T should increase inward
+        cmb_idx = np.argmax(mass_enclosed >= 0.325 * 5.972e24)
+        mantle_T = T[cmb_idx:]
+        # Mantle goes from CMB (lower index) to surface (higher index)
+        # T should decrease from CMB to surface (i.e. increase going inward)
+        assert mantle_T[0] > mantle_T[-1], (
+            f'Mantle T at CMB ({mantle_T[0]:.0f} K) should be > surface ({mantle_T[-1]:.0f} K)'
+        )
+
+
+@pytest.mark.unit
+class TestCalculateTemperatureProfileAdiabatic:
+    """Tests for 'adiabatic' mode in calculate_temperature_profile()."""
+
+    def test_adiabatic_returns_linear_initial_guess(self):
+        """Adiabatic mode should return a linear profile as the initial guess."""
+        radii = np.linspace(0, 6.371e6, 50)
+        T_surface = 3500.0
+        T_center = 6000.0
+
+        func = calculate_temperature_profile(
+            radii=radii,
+            temperature_mode='adiabatic',
+            surface_temperature=T_surface,
+            center_temperature=T_center,
+            input_dir='.',
+            temp_profile_file=None,
+        )
+        T = func(radii)
+
+        # Should match the linear profile
+        T_linear = T_surface + (T_center - T_surface) * (1 - radii / radii[-1])
+        np.testing.assert_allclose(T, T_linear, rtol=1e-10)
+
+    def test_adiabatic_invalid_mode_raises(self):
+        """An unknown temperature mode should raise ValueError."""
+        radii = np.linspace(0, 6.371e6, 50)
+        with pytest.raises(ValueError, match='Unknown temperature mode'):
+            calculate_temperature_profile(
+                radii=radii,
+                temperature_mode='nonexistent',
+                surface_temperature=3500.0,
+                center_temperature=6000.0,
+                input_dir='.',
+                temp_profile_file=None,
+            )

--- a/src/tests/test_adiabatic.py
+++ b/src/tests/test_adiabatic.py
@@ -6,8 +6,7 @@ Tests cover:
 - Adiabatic mode in calculate_temperature_profile()
 
 References:
-    - docs/test_infrastructure.md
-    - docs/test_categorization.md
+    - docs/testing.md
 """
 
 from __future__ import annotations

--- a/src/tools/compare_zeng2019.py
+++ b/src/tools/compare_zeng2019.py
@@ -86,9 +86,7 @@ COMPOSITIONS = {
     },
 }
 
-ZENG_DIR = os.path.join(
-    ZALMOXIS_ROOT, 'data', 'mass_radius_comparison_data', 'Zeng+2019_M-R_models'
-)
+ZENG_DIR = os.path.join(ZALMOXIS_ROOT, 'data', 'mass_radius_curves')
 OUTPUT_DIR = os.path.join(ZALMOXIS_ROOT, 'output_files', 'zeng_comparison')
 os.makedirs(OUTPUT_DIR, exist_ok=True)
 

--- a/src/tools/setup_utils.py
+++ b/src/tools/setup_utils.py
@@ -191,7 +191,7 @@ def download_data():
         folder='EOS_WolfBower2018_1TPa',
         data_dir=Path(ZALMOXIS_ROOT, 'data'),
         zenodo_id=17417017,
-        keep_files=['density_melt.dat', 'density_solid.dat'],
+        keep_files=['density_melt.dat', 'density_solid.dat', 'adiabat_temp_grad_melt.dat'],
     )
     download(
         folder='radial_profiles',
@@ -209,8 +209,8 @@ def download_data():
     download(
         folder='EOS_RTPress_melt_100TPa',
         data_dir=Path(ZALMOXIS_ROOT, 'data'),
-        zenodo_id=18812412,
-        keep_files=['density_melt.dat'],
+        zenodo_id=18819027,
+        keep_files=['density_melt.dat', 'adiabat_temp_grad_melt.dat'],
     )
     download(
         folder='melting_curves_Monteux-600',

--- a/src/tools/setup_utils.py
+++ b/src/tools/setup_utils.py
@@ -204,7 +204,13 @@ def download_data():
         data_dir=Path(ZALMOXIS_ROOT, 'data'),
         zenodo_id=15727899,
         osf_id='dpkjb',
-        keep_files=['massradiusEarthlikeRocky.txt', 'massradius_50percentH2O_300K_1mbar.txt'],
+        keep_files=[
+            'massradiusEarthlikeRocky.txt',
+            'massradiusFe.txt',
+            'massradiusmgsio3.txt',
+            'massradius_50percentH2O_300K_1mbar.txt',
+            'massradius_100percentH2O_300K_1mbar.txt',
+        ],
     )
     download(
         folder='EOS_RTPress_melt_100TPa',

--- a/src/zalmoxis/eos_functions.py
+++ b/src/zalmoxis/eos_functions.py
@@ -643,10 +643,20 @@ def compute_thermal_expansivity(
                 # Mixed: keep stencil between solidus and liquidus
                 T_lo = max(T_lo, T_sol)
                 T_hi = min(T_hi, T_liq)
-            # Ensure finite stencil width (at least 2 K)
+            # Ensure finite stencil width (at least 2 K).  This can
+            # happen in a narrow mixed zone where T_liq - T_sol < 2*dT.
+            # Re-apply phase boundary constraints on the widened stencil
+            # to avoid re-straddling the boundary we just clamped for.
             if T_hi - T_lo < 2.0:
                 T_lo = temperature - 1.0
                 T_hi = temperature + 1.0
+                if temperature <= T_sol:
+                    T_hi = min(T_hi, T_sol)
+                elif temperature >= T_liq:
+                    T_lo = max(T_lo, T_liq)
+                else:
+                    T_lo = max(T_lo, T_sol)
+                    T_hi = min(T_hi, T_liq)
 
     rho = calculate_density(
         pressure,

--- a/src/zalmoxis/eos_functions.py
+++ b/src/zalmoxis/eos_functions.py
@@ -510,9 +510,15 @@ def compute_adiabatic_temperature(
         if grad_file is not None:
             dtdp_dicts[eos_name] = {'melted_mantle': {'eos_file': grad_file}}
 
-    # Verify that any T-dep EOS in the config has an adiabat gradient table
+    # Verify that the mantle EOS supports adiabatic mode
     mantle_eos = layer_eos_config.get('mantle')
-    if mantle_eos in TDEP_EOS_NAMES and mantle_eos not in dtdp_dicts:
+    if mantle_eos not in TDEP_EOS_NAMES:
+        raise ValueError(
+            f'Adiabatic temperature mode requires a T-dependent mantle EOS '
+            f'(WolfBower2018:MgSiO3 or RTPress100TPa:MgSiO3), '
+            f"but got '{mantle_eos}'. Use 'linear' or 'isothermal' instead."
+        )
+    if mantle_eos not in dtdp_dicts:
         raise ValueError(
             f"Adiabatic mode requires an 'adiabat_grad_file' in the "
             f"melted_mantle material dictionary for EOS '{mantle_eos}'. "

--- a/src/zalmoxis/eos_functions.py
+++ b/src/zalmoxis/eos_functions.py
@@ -466,6 +466,13 @@ def compute_adiabatic_temperature(
 ):
     """Compute adiabatic T(r) using native (dT/dP)_S tables from the EOS.
 
+    This is a **standalone Zalmoxis feature** for structure calculations
+    where no external interior solver provides T(r).  In the PROTEUS-SPIDER
+    coupling, this function is NOT called because SPIDER computes its own
+    T(r) via entropy evolution.  See the comment block above ``_using_adiabat``
+    in ``zalmoxis.main()`` for details on why the adiabat gate is intentionally
+    not activated in the coupling workflow.
+
     Integrates T[i] = T[i+1] + (dT/dP)_S · (P[i] - P[i+1]) from surface
     inward.  The adiabatic gradient (dT/dP)_S = αT/(ρCp) is read directly
     from the ``adiabat_grad_file`` in the melt-phase material dictionary,

--- a/src/zalmoxis/eos_properties.py
+++ b/src/zalmoxis/eos_properties.py
@@ -24,6 +24,12 @@ material_properties_iron_silicate_planets = {
 }
 
 # Material Properties for iron/silicate planets with iron EOS according to Seager et al. (2007) and silicate melt EOS according to Wolf & Bower (2018)
+_wb_cp_melt = os.path.join(
+    ZALMOXIS_ROOT, 'data', 'EOS_WolfBower2018_1TPa', 'heat_capacity_melt.dat'
+)
+_wb_cp_solid = os.path.join(
+    ZALMOXIS_ROOT, 'data', 'EOS_WolfBower2018_1TPa', 'heat_capacity_solid.dat'
+)
 material_properties_iron_Tdep_silicate_planets = {
     'core': {
         # Iron, modeled in Seager et al. (2007) using the Vinet EOS fit to the epsilon phase of Fe and DFT calculations
@@ -35,18 +41,23 @@ material_properties_iron_Tdep_silicate_planets = {
         # MgSiO3 in melt state, modeled in Wolf & Bower (2018) using their developed high P–T RTpress EOS
         'eos_file': os.path.join(
             ZALMOXIS_ROOT, 'data', 'EOS_WolfBower2018_1TPa', 'density_melt.dat'
-        )
+        ),
+        **({'cp_file': _wb_cp_melt} if os.path.isfile(_wb_cp_melt) else {}),
     },
     'solid_mantle': {
         # MgSiO3 in solid state, modeled in Wolf & Bower (2018) using their developed high P–T RTpress EOS
         'eos_file': os.path.join(
             ZALMOXIS_ROOT, 'data', 'EOS_WolfBower2018_1TPa', 'density_solid.dat'
-        )
+        ),
+        **({'cp_file': _wb_cp_solid} if os.path.isfile(_wb_cp_solid) else {}),
     },
 }
 
 # Material Properties for iron/silicate planets with iron EOS according to Seager et al. (2007)
 # and silicate melt EOS from the extended RTpress table (100 TPa) with solid from Wolf & Bower (2018)
+_rt_cp_melt = os.path.join(
+    ZALMOXIS_ROOT, 'data', 'EOS_RTPress_melt_100TPa', 'heat_capacity_melt.dat'
+)
 material_properties_iron_RTPress100TPa_silicate_planets = {
     'core': {
         # Iron, modeled in Seager et al. (2007) using the Vinet EOS fit to the epsilon phase of Fe and DFT calculations
@@ -58,13 +69,16 @@ material_properties_iron_RTPress100TPa_silicate_planets = {
         # MgSiO3 in melt state, extended RTpress EOS table (P: 1e3–1e14 Pa, T: 400–50000 K)
         'eos_file': os.path.join(
             ZALMOXIS_ROOT, 'data', 'EOS_RTPress_melt_100TPa', 'density_melt.dat'
-        )
+        ),
+        **({'cp_file': _rt_cp_melt} if os.path.isfile(_rt_cp_melt) else {}),
     },
     'solid_mantle': {
         # MgSiO3 in solid state, from Wolf & Bower (2018) / Mosenfelder et al. (2009) (clamped at 1 TPa boundary)
         'eos_file': os.path.join(
             ZALMOXIS_ROOT, 'data', 'EOS_WolfBower2018_1TPa', 'density_solid.dat'
-        )
+        ),
+        # Solid Cp from WolfBower2018 (same tables used for solid density)
+        **({'cp_file': _wb_cp_solid} if os.path.isfile(_wb_cp_solid) else {}),
     },
 }
 

--- a/src/zalmoxis/eos_properties.py
+++ b/src/zalmoxis/eos_properties.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-import logging
 import os
-
-logger = logging.getLogger(__name__)
 
 # Read the environment variable for ZALMOXIS_ROOT
 ZALMOXIS_ROOT = os.getenv('ZALMOXIS_ROOT')
@@ -27,12 +24,6 @@ material_properties_iron_silicate_planets = {
 }
 
 # Material Properties for iron/silicate planets with iron EOS according to Seager et al. (2007) and silicate melt EOS according to Wolf & Bower (2018)
-_wb_cp_melt = os.path.join(
-    ZALMOXIS_ROOT, 'data', 'EOS_WolfBower2018_1TPa', 'heat_capacity_melt.dat'
-)
-_wb_cp_solid = os.path.join(
-    ZALMOXIS_ROOT, 'data', 'EOS_WolfBower2018_1TPa', 'heat_capacity_solid.dat'
-)
 material_properties_iron_Tdep_silicate_planets = {
     'core': {
         # Iron, modeled in Seager et al. (2007) using the Vinet EOS fit to the epsilon phase of Fe and DFT calculations
@@ -45,28 +36,20 @@ material_properties_iron_Tdep_silicate_planets = {
         'eos_file': os.path.join(
             ZALMOXIS_ROOT, 'data', 'EOS_WolfBower2018_1TPa', 'density_melt.dat'
         ),
-        **({'cp_file': _wb_cp_melt} if os.path.isfile(_wb_cp_melt) else {}),
+        'adiabat_grad_file': os.path.join(
+            ZALMOXIS_ROOT, 'data', 'EOS_WolfBower2018_1TPa', 'adiabat_temp_grad_melt.dat'
+        ),
     },
     'solid_mantle': {
         # MgSiO3 in solid state, modeled in Wolf & Bower (2018) using their developed high P–T RTpress EOS
         'eos_file': os.path.join(
             ZALMOXIS_ROOT, 'data', 'EOS_WolfBower2018_1TPa', 'density_solid.dat'
         ),
-        **({'cp_file': _wb_cp_solid} if os.path.isfile(_wb_cp_solid) else {}),
     },
 }
 
 # Material Properties for iron/silicate planets with iron EOS according to Seager et al. (2007)
 # and silicate melt EOS from the extended RTpress table (100 TPa) with solid from Wolf & Bower (2018)
-_rt_cp_melt = os.path.join(
-    ZALMOXIS_ROOT, 'data', 'EOS_RTPress_melt_100TPa', 'heat_capacity_melt.dat'
-)
-if not os.path.isfile(_rt_cp_melt):
-    logger.warning(
-        'RTPress100TPa melt Cp table not found at %s. '
-        'Adiabatic mode will fall back to constant Cp for this EOS.',
-        _rt_cp_melt,
-    )
 material_properties_iron_RTPress100TPa_silicate_planets = {
     'core': {
         # Iron, modeled in Seager et al. (2007) using the Vinet EOS fit to the epsilon phase of Fe and DFT calculations
@@ -79,15 +62,15 @@ material_properties_iron_RTPress100TPa_silicate_planets = {
         'eos_file': os.path.join(
             ZALMOXIS_ROOT, 'data', 'EOS_RTPress_melt_100TPa', 'density_melt.dat'
         ),
-        **({'cp_file': _rt_cp_melt} if os.path.isfile(_rt_cp_melt) else {}),
+        'adiabat_grad_file': os.path.join(
+            ZALMOXIS_ROOT, 'data', 'EOS_RTPress_melt_100TPa', 'adiabat_temp_grad_melt.dat'
+        ),
     },
     'solid_mantle': {
         # MgSiO3 in solid state, from Wolf & Bower (2018) / Mosenfelder et al. (2009) (clamped at 1 TPa boundary)
         'eos_file': os.path.join(
             ZALMOXIS_ROOT, 'data', 'EOS_WolfBower2018_1TPa', 'density_solid.dat'
         ),
-        # Solid Cp from WolfBower2018 (same tables used for solid density)
-        **({'cp_file': _wb_cp_solid} if os.path.isfile(_wb_cp_solid) else {}),
     },
 }
 

--- a/src/zalmoxis/eos_properties.py
+++ b/src/zalmoxis/eos_properties.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import logging
 import os
+
+logger = logging.getLogger(__name__)
 
 # Read the environment variable for ZALMOXIS_ROOT
 ZALMOXIS_ROOT = os.getenv('ZALMOXIS_ROOT')
@@ -58,6 +61,12 @@ material_properties_iron_Tdep_silicate_planets = {
 _rt_cp_melt = os.path.join(
     ZALMOXIS_ROOT, 'data', 'EOS_RTPress_melt_100TPa', 'heat_capacity_melt.dat'
 )
+if not os.path.isfile(_rt_cp_melt):
+    logger.warning(
+        'RTPress100TPa melt Cp table not found at %s. '
+        'Adiabatic mode will fall back to constant Cp for this EOS.',
+        _rt_cp_melt,
+    )
 material_properties_iron_RTPress100TPa_silicate_planets = {
     'core': {
         # Iron, modeled in Seager et al. (2007) using the Vinet EOS fit to the epsilon phase of Fe and DFT calculations

--- a/src/zalmoxis/zalmoxis.py
+++ b/src/zalmoxis/zalmoxis.py
@@ -239,9 +239,6 @@ def load_zalmoxis_config(temp_config_path=None):
         'target_surface_pressure': config['PressureAdjustment']['target_surface_pressure'],
         'pressure_tolerance': config['PressureAdjustment']['pressure_tolerance'],
         'max_iterations_pressure': config['PressureAdjustment']['max_iterations_pressure'],
-        'pressure_adjustment_factor': config['PressureAdjustment'][
-            'pressure_adjustment_factor'
-        ],
         'adiabatic_cp': config['AssumptionsAndInitialGuesses'].get('adiabatic_cp', 1200.0),
         'data_output_enabled': config['Output']['data_enabled'],
         'plotting_enabled': config['Output']['plots_enabled'],

--- a/src/zalmoxis/zalmoxis.py
+++ b/src/zalmoxis/zalmoxis.py
@@ -393,7 +393,7 @@ def main(config_params, material_dictionaries, melting_curves_functions, input_d
         solidus_func, liquidus_func = None, None
 
     # Storage for the previous iteration's converged profiles.
-    # Used by adiabatic mode to compute T(r) from the last P(r), g(r).
+    # Used by adiabatic mode to compute T(r) from the last P(r) and M(r).
     prev_radii = None
     prev_pressure = None
     prev_mass_enclosed = None
@@ -402,7 +402,7 @@ def main(config_params, material_dictionaries, melting_curves_functions, input_d
     # Phase 1: converge the structure using a linear T initial guess
     #          (same as 'linear' mode — stable and robust).
     # Phase 2: once the mass converges, switch to the dT/dP adiabat
-    #          computed from the converged P(r) and g(r), then re-converge.
+    #          computed from the converged P(r) and M(r), then re-converge.
     # Without this, a half-converged P(r) produces a bad adiabat that
     # prevents the solver from ever converging.
     _using_adiabat = False

--- a/src/zalmoxis/zalmoxis.py
+++ b/src/zalmoxis/zalmoxis.py
@@ -514,20 +514,18 @@ def main(config_params, material_dictionaries, melting_curves_functions, input_d
             if uses_WB2018:
                 p_high = min(p_high, max_center_pressure_guess)
 
-            # Pre-validate that the bracket straddles the root (f changes sign).
-            # Without this, brentq raises a cryptic ValueError.
-            f_low = _pressure_residual(p_low)
-            f_high = _pressure_residual(p_high)
-            if f_low * f_high > 0:
-                raise ValueError(
-                    f'Brent bracket does not straddle the root: '
-                    f'f({p_low:.2e})={f_low:.2e}, f({p_high:.2e})={f_high:.2e}. '
-                    f'The target surface pressure may be unreachable for this mass '
-                    f'and EOS combination. Try adjusting planet_mass or '
-                    f'target_surface_pressure.'
-                )
-
             try:
+                # Pre-validate that the bracket straddles the root.
+                # This gives a clearer error than brentq's generic ValueError,
+                # and the except handler below gracefully falls back to the
+                # last evaluated solution.
+                f_low = _pressure_residual(p_low)
+                f_high = _pressure_residual(p_high)
+                if f_low * f_high > 0:
+                    raise ValueError(
+                        f'Brent bracket does not straddle the root: '
+                        f'f({p_low:.2e})={f_low:.2e}, f({p_high:.2e})={f_high:.2e}.'
+                    )
                 p_solution, root_info = brentq(
                     _pressure_residual,
                     p_low,

--- a/src/zalmoxis/zalmoxis.py
+++ b/src/zalmoxis/zalmoxis.py
@@ -646,7 +646,16 @@ def main(config_params, material_dictionaries, melting_curves_functions, input_d
 
         # Update radius guess
         calculated_mass = mass_enclosed[-1]
-        radius_guess = radius_guess * (planet_mass / calculated_mass) ** (1 / 3)
+        if calculated_mass <= 0 or not np.isfinite(calculated_mass):
+            # Structure solver failed to produce valid mass (e.g. pressure
+            # dropped to zero near the center).  Shrink radius and retry.
+            radius_guess *= 0.8
+            logger.warning(
+                f'Outer iter {outer_iter}: calculated_mass={calculated_mass:.2e}, '
+                f'shrinking radius_guess to {radius_guess:.0f} m.'
+            )
+        else:
+            radius_guess = radius_guess * (planet_mass / calculated_mass) ** (1 / 3)
         cmb_mass = core_mass_fraction * calculated_mass
         core_mantle_mass = (core_mass_fraction + mantle_mass_fraction) * calculated_mass
 

--- a/src/zalmoxis/zalmoxis.py
+++ b/src/zalmoxis/zalmoxis.py
@@ -514,6 +514,19 @@ def main(config_params, material_dictionaries, melting_curves_functions, input_d
             if uses_WB2018:
                 p_high = min(p_high, max_center_pressure_guess)
 
+            # Pre-validate that the bracket straddles the root (f changes sign).
+            # Without this, brentq raises a cryptic ValueError.
+            f_low = _pressure_residual(p_low)
+            f_high = _pressure_residual(p_high)
+            if f_low * f_high > 0:
+                raise ValueError(
+                    f'Brent bracket does not straddle the root: '
+                    f'f({p_low:.2e})={f_low:.2e}, f({p_high:.2e})={f_high:.2e}. '
+                    f'The target surface pressure may be unreachable for this mass '
+                    f'and EOS combination. Try adjusting planet_mass or '
+                    f'target_surface_pressure.'
+                )
+
             try:
                 p_solution, root_info = brentq(
                     _pressure_residual,

--- a/src/zalmoxis/zalmoxis.py
+++ b/src/zalmoxis/zalmoxis.py
@@ -239,7 +239,6 @@ def load_zalmoxis_config(temp_config_path=None):
         'target_surface_pressure': config['PressureAdjustment']['target_surface_pressure'],
         'pressure_tolerance': config['PressureAdjustment']['pressure_tolerance'],
         'max_iterations_pressure': config['PressureAdjustment']['max_iterations_pressure'],
-        'adiabatic_cp': config['AssumptionsAndInitialGuesses'].get('adiabatic_cp', 1200.0),
         'data_output_enabled': config['Output']['data_enabled'],
         'plotting_enabled': config['Output']['plots_enabled'],
         'verbose': config['Output']['verbose'],
@@ -337,7 +336,6 @@ def main(config_params, material_dictionaries, melting_curves_functions, input_d
     target_surface_pressure = config_params['target_surface_pressure']
     pressure_tolerance = config_params['pressure_tolerance']
     max_iterations_pressure = config_params['max_iterations_pressure']
-    adiabatic_cp = config_params.get('adiabatic_cp', 1200.0)
     verbose = config_params['verbose']
     iteration_profiles_enabled = config_params['iteration_profiles_enabled']
 
@@ -398,7 +396,6 @@ def main(config_params, material_dictionaries, melting_curves_functions, input_d
     # Used by adiabatic mode to compute T(r) from the last P(r), g(r).
     prev_radii = None
     prev_pressure = None
-    prev_gravity = None
     prev_mass_enclosed = None
 
     # Solve the interior structure
@@ -411,25 +408,17 @@ def main(config_params, material_dictionaries, melting_curves_functions, input_d
         pressure = np.zeros(num_layers)
 
         if uses_Tdep:
-            if (
-                temperature_mode == 'adiabatic'
-                and outer_iter > 0
-                and prev_pressure is not None
-            ):
+            if temperature_mode == 'adiabatic' and outer_iter > 0 and prev_pressure is not None:
                 # Recompute adiabat from previous iteration's converged structure
                 adiabat_T = compute_adiabatic_temperature(
                     prev_radii,
                     prev_pressure,
-                    prev_gravity,
                     prev_mass_enclosed,
                     surface_temperature,
-                    adiabatic_cp,
                     cmb_mass,
                     core_mantle_mass,
                     layer_eos_config,
                     material_dictionaries,
-                    solidus_func,
-                    liquidus_func,
                     interpolation_cache,
                 )
 
@@ -642,7 +631,6 @@ def main(config_params, material_dictionaries, melting_curves_functions, input_d
         # Save converged profiles for the next outer iteration's adiabat
         prev_radii = radii.copy()
         prev_pressure = np.asarray(pressure).copy()
-        prev_gravity = np.asarray(gravity).copy()
         prev_mass_enclosed = np.asarray(mass_enclosed).copy()
 
         # Update radius guess

--- a/src/zalmoxis/zalmoxis.py
+++ b/src/zalmoxis/zalmoxis.py
@@ -689,9 +689,21 @@ def main(config_params, material_dictionaries, melting_curves_functions, input_d
         relative_diff_outer_mass = np.abs((calculated_mass - planet_mass) / planet_mass)
 
         if relative_diff_outer_mass < tolerance_outer:
-            logger.info(f'Outer loop (total mass) converged after {outer_iter + 1} iterations.')
-            converged_mass = True
-            break
+            if temperature_mode == 'adiabatic' and not _using_adiabat:
+                # Mass converged with linear T — don't break yet.
+                # The gate at the top of the next iteration will switch
+                # to adiabatic mode and re-converge.
+                verbose and logger.info(
+                    f'Outer iter {outer_iter}: mass converged with linear T '
+                    f'(rdiff={relative_diff_outer_mass:.2e}), '
+                    f'continuing to activate adiabatic mode.'
+                )
+            else:
+                logger.info(
+                    f'Outer loop (total mass) converged after {outer_iter + 1} iterations.'
+                )
+                converged_mass = True
+                break
 
         if outer_iter == max_iterations_outer - 1:
             verbose and logger.warning(

--- a/src/zalmoxis/zalmoxis.py
+++ b/src/zalmoxis/zalmoxis.py
@@ -689,21 +689,9 @@ def main(config_params, material_dictionaries, melting_curves_functions, input_d
         relative_diff_outer_mass = np.abs((calculated_mass - planet_mass) / planet_mass)
 
         if relative_diff_outer_mass < tolerance_outer:
-            if temperature_mode == 'adiabatic' and not _using_adiabat:
-                # Mass converged with linear T — don't break yet.
-                # The gate at the top of the next iteration will switch
-                # to adiabatic mode and re-converge.
-                verbose and logger.info(
-                    f'Outer iter {outer_iter}: mass converged with linear T '
-                    f'(rdiff={relative_diff_outer_mass:.2e}), '
-                    f'continuing to activate adiabatic mode.'
-                )
-            else:
-                logger.info(
-                    f'Outer loop (total mass) converged after {outer_iter + 1} iterations.'
-                )
-                converged_mass = True
-                break
+            logger.info(f'Outer loop (total mass) converged after {outer_iter + 1} iterations.')
+            converged_mass = True
+            break
 
         if outer_iter == max_iterations_outer - 1:
             verbose and logger.warning(

--- a/src/zalmoxis/zalmoxis.py
+++ b/src/zalmoxis/zalmoxis.py
@@ -392,19 +392,42 @@ def main(config_params, material_dictionaries, melting_curves_functions, input_d
     else:
         solidus_func, liquidus_func = None, None
 
+    # --- Adiabatic temperature mode (standalone Zalmoxis only) -----------
+    #
+    # When temperature_mode='adiabatic', Zalmoxis computes a self-consistent
+    # T(r) from dT/dP adiabat tables.  This is a STANDALONE Zalmoxis feature
+    # for structure calculations where no external interior solver provides
+    # T(r).
+    #
+    # In the PROTEUS-SPIDER-Zalmoxis coupling, this mode is NOT used for
+    # thermal evolution.  SPIDER computes its own adiabatic T(r) via entropy-
+    # based evolution (T-S formalism).  Zalmoxis only provides the initial
+    # structure mesh (r, P, rho, g).  PROTEUS sets temperature_mode='adiabatic'
+    # in the config, but the convergence loop below breaks on mass convergence
+    # BEFORE the adiabat gate fires — so the structure is solved with a
+    # linear T initial guess.  This is correct: the T profile only affects
+    # the density (via T-dep EOS), and the density difference between linear T
+    # and an adiabat is small enough (~5-10%) to produce a valid mesh.  SPIDER
+    # then self-corrects T(r) through its own physics.
+    #
+    # WARNING: Do NOT prevent the mass-convergence break (line ~691) from
+    # firing in order to force the adiabat gate to activate.  Switching from
+    # a converged linear-T structure to an adiabat disrupts the converged
+    # state, and the iterative solver diverges (mass→0, radius→15 R_earth).
+    # If standalone adiabat mode is needed, the transition must be gradual
+    # (e.g., blended T) or the solver must be restructured for co-refinement.
+    # -------------------------------------------------------------------
+
     # Storage for the previous iteration's converged profiles.
     # Used by adiabatic mode to compute T(r) from the last P(r) and M(r).
     prev_radii = None
     prev_pressure = None
     prev_mass_enclosed = None
 
-    # Two-phase convergence for adiabatic mode:
-    # Phase 1: converge the structure using a linear T initial guess
-    #          (same as 'linear' mode — stable and robust).
-    # Phase 2: once the mass converges, switch to the dT/dP adiabat
-    #          computed from the converged P(r) and M(r), then re-converge.
-    # Without this, a half-converged P(r) produces a bad adiabat that
-    # prevents the solver from ever converging.
+    # Adiabat gate: activates once mass converges (see long comment above).
+    # In PROTEUS coupling, the break at line ~691 fires first, so
+    # _using_adiabat stays False and compute_adiabatic_temperature() is
+    # never called.  This is intentional.
     _using_adiabat = False
 
     # Solve the interior structure
@@ -417,8 +440,14 @@ def main(config_params, material_dictionaries, melting_curves_functions, input_d
         pressure = np.zeros(num_layers)
 
         if uses_Tdep:
-            # Graduate to adiabat once mass is within tolerance.
-            # Once graduated, stay on the adiabat (don't oscillate back).
+            # ADIABAT GATE — activates compute_adiabatic_temperature() once
+            # the mass has converged with a linear T guess.  In practice,
+            # the break at the bottom of the outer loop (line ~691) fires
+            # on mass convergence BEFORE the next iteration reaches this
+            # gate, so this code path is not exercised in the PROTEUS
+            # coupling.  It exists for standalone Zalmoxis use where the
+            # adiabat would provide a better T(r) than a linear guess.
+            # See the long comment block above _using_adiabat for context.
             if not _using_adiabat and temperature_mode == 'adiabatic':
                 prev_mass_converged = (
                     prev_mass_enclosed is not None
@@ -688,6 +717,13 @@ def main(config_params, material_dictionaries, melting_curves_functions, input_d
 
         relative_diff_outer_mass = np.abs((calculated_mass - planet_mass) / planet_mass)
 
+        # MASS CONVERGENCE BREAK — exits the outer loop when total mass
+        # matches the target.  This break fires before the adiabat gate
+        # at the top of the loop can activate (both check the same
+        # tolerance on successive iterations).  This is correct for the
+        # PROTEUS coupling where SPIDER handles T(r) evolution.
+        # Do NOT add conditions that skip this break — see the warning
+        # in the comment block above _using_adiabat.
         if relative_diff_outer_mass < tolerance_outer:
             logger.info(f'Outer loop (total mass) converged after {outer_iter + 1} iterations.')
             converged_mass = True


### PR DESCRIPTION
## Overview

This PR adds an adiabatic temperature mode to Zalmoxis that computes physically self-consistent temperature profiles through the planet interior. Previously, Zalmoxis could only assign a uniform temperature or a linear temperature gradient when computing the density structure. The new mode integrates the adiabatic temperature gradient (dT/dP at constant entropy) directly from pre-tabulated values in the equation of state data, giving realistic initial temperature profiles for magma ocean simulations.

### How this connects to the other two PRs

This is one of three coordinated PRs that together enable coupled interior structure and thermal evolution for rocky planets:

- **SPIDER PR** ([#5](https://github.com/FormingWorlds/SPIDER/pull/5)): Accepts externally-computed density profiles and adds numerical safety for extreme conditions
- **This PR (Zalmoxis)**: Computes physically self-consistent density structures and temperature profiles for planets of arbitrary mass and composition
- **PROTEUS PR** ([#648](https://github.com/FormingWorlds/PROTEUS/pull/648)): Orchestrates the coupling between Zalmoxis and SPIDER, handling mesh interpolation, entropy remapping, and iterative structure feedback

The merge order is: **SPIDER PR + this PR first** (independent of each other), then the PROTEUS PR (which depends on both).

### Why this matters

When PROTEUS starts a magma ocean simulation, it needs an initial temperature profile through the mantle. This temperature profile determines the initial melt fraction, which controls how quickly the planet begins to solidify. For temperature-dependent equations of state (like Wolf & Bower 2018 for MgSiO₃), the temperature also affects the density, which in turn changes the pressure profile and gravitational acceleration. The adiabatic mode solves this coupled problem self-consistently: given a surface temperature, it integrates the adiabatic gradient downward through the mantle, adjusting density and pressure at each step based on the local temperature.

### How the adiabatic mode works

The implementation integrates the melt-phase adiabatic gradient (dT/dP)_S from pre-tabulated values that are part of the equation of state data. Starting from the surface temperature (set by the atmosphere), the code steps inward through the mantle, computing the temperature increase at each pressure level. This produces a temperature profile that is thermodynamically consistent with the equation of state — the temperature at each depth is what a convecting fluid parcel would have if it descended adiabatically from the surface.

The computation uses a two-pass convergence approach: the first pass computes the density structure using a linear temperature guess (which is robust and always converges), and the second pass refines the structure using the adiabatic temperature profile computed from the first-pass pressure values. This avoids the chicken-and-egg problem where the adiabat depends on pressure (which depends on density, which depends on temperature).

The iron core is treated as isothermal because the Seager (2007) equation of state used for iron does not include temperature dependence. A temperature ceiling extracted from the equation of state tables prevents extrapolation beyond the validated range.

### Which equations of state support the adiabatic mode?

The adiabatic mode requires pre-tabulated adiabatic gradients (dT/dP)_S, which are stored in an `adiabat_temp_grad_melt.dat` file alongside each equation of state. Currently, two mantle equations of state include these tables:

- **WolfBower2018:MgSiO₃** — covers pressures up to ~430 GPa (sufficient for planets up to ~3 Earth masses)
- **RTPress100TPa:MgSiO₃** — covers pressures up to 100 TPa (sufficient for super-Earths up to ~10 Earth masses)

Temperature-independent equations of state (**Seager2007:iron**, **Seager2007:MgSiO₃**) do not support the adiabatic mode because they have no temperature dependence at all — density is a function of pressure only.

If a user selects `temperature_mode = "adiabatic"` with an unsupported equation of state, Zalmoxis raises an explicit error message listing the supported options and suggesting `"linear"` or `"isothermal"` as alternatives. This prevents silent misconfiguration.

For PROTEUS coupled simulations, the temperature mode is set automatically: when SPIDER is the interior module and a temperature-dependent mantle equation of state is selected, PROTEUS switches to adiabatic mode without user intervention.

## Changes

- `eos_functions.py`: New `compute_adiabatic_temperature()` function that integrates dT/dP tables from surface inward; `_get_melt_tmax()` to extract temperature ceiling from equation of state tables
- `eos_properties.py`: Load the `adiabat_temp_grad_melt.dat` gradient table for temperature-dependent equations of state
- `zalmoxis.py`: Two-pass convergence loop (first pass with linear temperature guess to get approximate density, second pass with adiabatic temperature to refine), radius iteration damping for numerical stability
- `constants.py`: Registry of T-dependent EOS names (`TDEP_EOS_NAMES`) for adiabatic mode compatibility checks
- `structure_model.py`: Improved numerical robustness for extreme mass/composition combinations
- `docs/model.md`: Document the adiabat computation method
- `tests/test_adiabatic.py`: 9 unit tests covering surface temperature, core isothermality, monotonicity, and divergence regression

## Validation

All 24 standalone tests pass (macOS, Python 3.12).

### Test 1: Mass-radius relation — does Zalmoxis produce physically correct planet sizes?

To verify that the structure solver gives correct results, I compared Zalmoxis planet radii against published mass-radius scaling laws from Zeng et al. (2019) for three compositions: pure iron, Earth-like (32.5% iron core), and pure silicate.

**Why this test**: This is the most basic correctness check for any structure solver. If the mass-radius relation is wrong, everything built on top of it will be wrong.

**Result**: Zalmoxis reproduces the published relations within 3% across 0.5 to 10 Earth masses for all three compositions.

![Mass-radius relation](https://github.com/timlichtenberg/pr-assets/releases/download/assets/20260301-220012-plot06_mass_radius.png)

### Test 2: Temperature-dependent equation of state — do density profiles respond to temperature changes?

When using a temperature-dependent equation of state (Wolf & Bower 2018), the mantle density should change as the planet cools because thermal contraction makes the material denser. I compared density profiles at the start (fully molten) and end (partially solidified) of coupled simulations.

**Why this test**: The temperature-dependent equation of state is the whole point of coupling Zalmoxis with SPIDER. If the density does not respond to temperature, the coupling adds nothing. Note that Zalmoxis already handles mixed phases: in partially molten regions, it computes a volume-additive mixed density from both solid and melt tables, weighted by melt fraction.

**Result**: Density increases by 5–15% as the mantle solidifies, with the effect scaling with planet mass as expected from the pressure-temperature sensitivity of the equation of state.

![Temperature-dependent density](https://github.com/timlichtenberg/pr-assets/releases/download/assets/20260301-220012-plot07_tdep_eos.png)

### Test 3: Adiabatic temperature profiles — does the new mode produce reasonable initial temperatures?

The adiabatic mode should produce temperature profiles that increase smoothly from the surface to the core-mantle boundary, following the melt-phase adiabatic gradient. The core (iron) should be isothermal because the iron equation of state does not include temperature dependence.

**Why this test**: This validates the core new feature of this PR. The profile must be monotonically increasing with depth, must not diverge, and must stay within the equation of state table bounds.

**Result**: Temperature increases smoothly from the surface (set by the atmosphere) to 4,700–4,800 K at the core-mantle boundary for both 1 and 3 Earth mass planets. The core is isothermal.

![Adiabatic profiles](https://github.com/timlichtenberg/pr-assets/releases/download/assets/20260301-220012-plot08_adiabatic_profiles.png)

### Test 4: Divergence regression — can the extreme cases run without crashing?

I ran the 3 Earth mass, 10% iron core case — one of the most extreme configurations in the parameter space — which is the most demanding test for the adiabatic mode because it has the thickest mantle and highest core-mantle boundary pressures (~670 GPa).

**Why this test**: Extreme mass and composition combinations stress the adiabatic integration, the equation of state tables, and the convergence algorithm simultaneously. If this case works, simpler configurations will too.

**Result**: The case cools smoothly from 3,400 K to 715 K over 1 million years of simulated time, with no temperature divergence at any depth.

![Divergence regression](https://github.com/timlichtenberg/pr-assets/releases/download/assets/20260301-220012-plot09_divergence_regression.png)

### Test 5: Crash regression matrix — do all parameter combinations run successfully?

I ran the full parameter grid (3 masses × 3 core fractions × multiple modes) on the Habrok computing cluster to verify that no cases crash with the new code.

**Why this test**: Individual case fixes sometimes introduce regressions elsewhere. A systematic parameter study across the full space ensures robustness.

**Result**: All 18 Zalmoxis cases complete successfully (0 crashes).

![Crash regression](https://github.com/timlichtenberg/pr-assets/releases/download/assets/20260301-220012-plot10_crash_matrix.png)

### Test 6: Adiabatic vs linear initial temperature — does the choice of initial profile matter?

To check whether the adiabatic initial temperature profile significantly affects the simulation outcome, I ran matched cases using the adiabatic mode and a simple linear temperature gradient as initial conditions, then compared how long each planet took to solidify.

**Why this test**: If the solidification time is very sensitive to the initial temperature profile, users need to be careful about this choice. If insensitive, the adiabatic mode is a convenience for physical consistency rather than a necessity for accuracy.

**Result**: Solidification times agree within ~10% between adiabatic and linear initial temperatures for all cases that solidify within the simulation time limit. The initial temperature "memory" is erased within the first few thousand years of cooling, as the convective interior quickly relaxes to its own thermal state regardless of the starting profile.

The one data point in the upper-right corner of the plot is the 3 Earth mass, 10% iron core case. This planet never fully solidifies within the 1 million year simulation limit — residual deep melt persists at ~1–2% because the melting curve at extreme core-mantle boundary pressures (>600 GPa) approaches the equation of state table boundary. The plotted "solidification time" for this case is simply when the simulation stopped, not when the planet solidified. The adiabatic run happened to continue slightly longer (1,107 kyr vs 1,003 kyr) before hitting the time limit, which is why the point sits slightly off the 1:1 line. This is not a physical difference — both runs have nearly identical thermal states at the point where each stopped.

![Adiabatic vs linear](https://github.com/timlichtenberg/pr-assets/releases/download/assets/20260301-220012-plot11_adiabat_vs_linear.png)

## Challenges during development

- **Two-pass convergence**: Because the density depends on temperature (through the equation of state) and the temperature depends on density (through the adiabatic gradient and gravitational acceleration), the problem is nonlinear. A single-pass computation is insufficient — the code now uses a two-pass approach: first computing structure with a linear temperature guess, then refining with the adiabatic profile. Convergence required damping the radius iteration to prevent oscillation.
- **Equation of state table coverage**: The Wolf & Bower 2018 tables for solid MgSiO₃ do not extend to the same entropy range as the melt tables. At very high pressures, the initial adiabat can cross into the solid phase where the table runs out. The temperature ceiling clamp handles this gracefully, but it took several iterations to get the clamping logic right without introducing discontinuities.
- **Numerical stability for extreme compositions**: Planets with very small iron cores (10% of total mass) at 3 Earth masses produce core-mantle boundary pressures above 600 GPa. At these pressures, the density contrast between core and mantle is extreme, and the radius iteration can oscillate. The damping factor in the radius update was tuned to handle this without over-damping the convergence for simpler cases.

## What was not tackled / future work

- **Core temperature evolution**: The iron core is assumed isothermal because the Seager (2007) equation of state used for iron does not include temperature dependence. Incorporating a temperature-dependent iron equation of state would enable modelling core cooling and its effect on the mantle base temperature.
- **Higher-mass planets**: The current validation covers 1–3 Earth masses. Extending to 5–10 Earth masses would require validating the RTPress100TPa equation of state tables in coupled simulations. The code already supports these tables, but they have not been tested end-to-end.
- **Compositional gradients**: Zalmoxis currently assumes a homogeneous mantle composition. Supporting radial compositional gradients (e.g. from magma ocean fractionation) would be a significant extension.
- **Solid-phase adiabatic gradient**: The current adiabatic mode uses melt-phase gradients only, which is correct for the fully molten initial condition of a magma ocean. For computing temperature profiles in partially or fully solidified mantles, solid-phase adiabatic gradient tables would be needed.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required