### PR TITLE
Add nightly cron workflow for heavy test tier

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,6 +11,12 @@ on:
   # ``gh workflow run "Zalmoxis nightly" -r <branch>``).
   workflow_dispatch:
 
+# Least-privilege token: only read access to the repo contents.
+# Coverage upload uses the CODECOV_TOKEN secret directly, not the
+# default GITHUB_TOKEN.
+permissions:
+  contents: read
+
 # Nightly: full test suite (unit + integration, plus smoke tier on
 # branches that define it) with coverage instrumentation. Targets
 # <60 min wall. Excluded from push and PR CI because each integration
@@ -25,8 +31,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,62 @@
+name: Zalmoxis nightly
+
+on:
+  schedule:
+    # 02:00 UTC daily. CRON syntax is in UTC; 02:00 UTC is roughly
+    # 03:00 / 04:00 CET (DST-dependent). Adjust the hour if you'd
+    # rather pin to a specific local time.
+    - cron: "0 2 * * *"
+  # Manual trigger for ad-hoc runs (e.g. before cutting a release,
+  # or to verify the suite on a feature branch via
+  # ``gh workflow run "Zalmoxis nightly" -r <branch>``).
+  workflow_dispatch:
+
+# Nightly: full test suite (unit + integration, plus smoke tier on
+# branches that define it) with coverage instrumentation. Targets
+# <60 min wall. Excluded from push and PR CI because each integration
+# test runs a full Zalmoxis solver call (5-10 min on a 2-vCPU runner
+# under cov instrumentation) and burning that on every push gives no
+# bug-finding signal that the unit suite doesn't already cover.
+jobs:
+  nightly:
+    name: Zalmoxis-nightly (ubuntu-latest)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12.9"
+
+      - name: Set ZALMOXIS_ROOT environment variable
+        run: echo "ZALMOXIS_ROOT=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          pip install pytest pytest-cov pytest-xdist
+
+      - name: Download required input/output files
+        run: |
+          bash src/get_zalmoxis.sh
+
+      - name: Run unit + smoke + integration tests with coverage
+        run: |
+          pytest -m "(unit or smoke or integration) and not slow" -n auto -o "addopts=" \
+            --cov=src --cov-report=term-missing --cov-report=xml
+
+      - name: Upload coverage to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: FormingWorlds/Zalmoxis
+          files: coverage.xml
+          flags: nightly
+          fail_ci_if_error: false


### PR DESCRIPTION
## Description

Adds `.github/workflows/nightly.yml`: a scheduled workflow that runs the full test suite (`(unit or smoke or integration) and not slow`) with coverage instrumentation, on a 60-min ubuntu-latest runner, every day at 02:00 UTC and on `workflow_dispatch`.

This is purely additive — push CI (`CI.yml`) is unchanged in this PR.

The motivation for splitting heavy tests off from push CI: integration tests each run a full Zalmoxis solver call that takes 5-10 min on a 2-vCPU runner under coverage instrumentation. Running them on every push burns ~30-60 min CI time per commit while giving no bug-finding signal beyond what the unit suite already covers. Moving them to a daily cron keeps push CI fast and preserves coverage tracking for the heavier tiers.

The companion change on `tl/interior-refactor` (a separate, larger PR not yet merged) restructures push CI to be unit-only (<5 min) and adds a `smoke` marker tier. Landing this nightly workflow on `main` first lets us register the workflow with GitHub Actions so it can be triggered manually via `gh workflow run "Zalmoxis nightly" -r tl/interior-refactor` to verify wall-time before merging the larger restructure.

## Validation of changes

- `nightly.yml` parses as valid YAML.
- Paths reference scripts that exist on `main` (`src/get_zalmoxis.sh`, `--cov=src`).
- Cron schedule `"0 2 * * *"` is standard UTC syntax.
- Coverage upload uses the existing `CODECOV_TOKEN` secret already configured for `CI.yml`.
- The `smoke` marker filter is harmless on `main` (no tests are tagged `smoke` here, so the filter just matches `unit or integration`).

The first cron firing will happen at the next 02:00 UTC after merge. Manual triggers via `gh workflow run` are available immediately.

## Checklist

- [x] I have followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate (no docs change needed for a workflow file)
- [ ] I have added tests for these changes, as appropriate (CI infrastructure, no tests added)
- [x] I have checked that all dependencies have been updated, as required