### PR TITLE
Pin scipy below 1.18 to fix the flapping nightly EOS-cache load

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,11 @@ classifiers = [
 ]
 dependencies = [
     "numpy",
-    "scipy",
+    # Upper bound: scipy 1.18 dropped the vendored scipy._lib.array_api_compat
+    # module that pickled EOS interpolator caches (RegularGridInterpolator,
+    # NearestNDInterpolator) reference, so loading a cache fails to unpickle on
+    # scipy >= 1.18. Lower bound follows the JAX stack, which requires scipy >= 1.14.
+    "scipy>=1.14,<1.18",
     "toml",
     "matplotlib",
     "python-ternary",

--- a/src/zalmoxis/eos/interpolation.py
+++ b/src/zalmoxis/eos/interpolation.py
@@ -563,7 +563,18 @@ def _ensure_unified_cache(eos_file, interpolation_functions):
             with open(cache_path, 'rb') as f:
                 interpolation_functions[eos_file] = pickle.load(f)
             logger.debug('Loaded PALEOS cache from %s', cache_path)
-        except (FileNotFoundError, EOFError, pickle.UnpicklingError):
+        except (
+            FileNotFoundError,
+            EOFError,
+            pickle.UnpicklingError,
+            ImportError,
+            AttributeError,
+        ):
+            # ImportError/AttributeError cover a cache pickled by a different
+            # scipy build whose interpolator classes or vendored submodules
+            # (e.g. scipy._lib.array_api_compat) no longer resolve. Rebuilding
+            # from the text table always produces a cache valid for the current
+            # scipy, so a stale binary cache degrades to a slow load, not a crash.
             logger.info('Loading PALEOS table from text: %s', eos_file)
             interpolation_functions[eos_file] = load_paleos_unified_table(eos_file)
             # Save binary cache for next time

--- a/src/zalmoxis/eos/interpolation.py
+++ b/src/zalmoxis/eos/interpolation.py
@@ -569,13 +569,27 @@ def _ensure_unified_cache(eos_file, interpolation_functions):
             pickle.UnpicklingError,
             ImportError,
             AttributeError,
-        ):
-            # ImportError/AttributeError cover a cache pickled by a different
-            # scipy build whose interpolator classes or vendored submodules
+        ) as exc:
+            # FileNotFoundError is the normal first-load case (no cache yet). The
+            # other errors mean a cache file exists but cannot be unpickled, most
+            # often because it was written by a different scipy build whose
+            # interpolator classes or vendored submodules
             # (e.g. scipy._lib.array_api_compat) no longer resolve. Rebuilding
             # from the text table always produces a cache valid for the current
             # scipy, so a stale binary cache degrades to a slow load, not a crash.
-            logger.info('Loading PALEOS table from text: %s', eos_file)
+            if isinstance(exc, FileNotFoundError):
+                logger.info('Loading PALEOS table from text: %s', eos_file)
+            else:
+                # Record why the cache was rejected so a scipy-version mismatch
+                # is distinguishable from a corrupt or partial cache in ops logs.
+                logger.info(
+                    'PALEOS binary cache %s could not be loaded (%s: %s); '
+                    'rebuilding from text table',
+                    cache_path,
+                    type(exc).__name__,
+                    exc,
+                )
+                logger.debug('PALEOS cache load failure traceback', exc_info=True)
             interpolation_functions[eos_file] = load_paleos_unified_table(eos_file)
             # Save binary cache for next time
             try:

--- a/tests/test_eos_functions.py
+++ b/tests/test_eos_functions.py
@@ -21,6 +21,7 @@ References:
 from __future__ import annotations
 
 import os
+import pickle
 import tempfile
 
 import numpy as np
@@ -330,6 +331,68 @@ class TestEnsureUnifiedCache:
         assert result['type'] == 'paleos_unified'
         assert 'density_interp' in result
         assert 'nabla_ad_interp' in result
+
+    def test_rebuilds_when_cache_references_missing_module(self, tmp_path):
+        """A binary cache that cannot be unpickled rebuilds from the text table.
+
+        A cache pickled by one scipy build embeds the fully-qualified class
+        paths of its interpolator objects (and vendored submodules such as
+        scipy._lib.array_api_compat). Loading that cache under a scipy build
+        that no longer ships those paths raises ModuleNotFoundError, a subclass
+        of ImportError. The loader must treat the binary cache as unusable and
+        rebuild from the authoritative text table instead of propagating.
+        """
+        from unittest.mock import patch
+
+        from zalmoxis.eos import _ensure_unified_cache
+
+        eos_file = str(tmp_path / 'fake_table.dat')
+        cache_path = str(tmp_path / 'fake_table.pkl')
+
+        # GLOBAL opcode referencing a module that cannot be imported: the exact
+        # failure shape of a scipy-version-mismatched interpolator cache.
+        bad_pickle = b'\x80\x04c__zalmoxis_absent_module__\nFoo\n.'
+        with pytest.raises(ModuleNotFoundError):
+            pickle.loads(bad_pickle)
+        with open(cache_path, 'wb') as f:
+            f.write(bad_pickle)
+
+        rebuilt = {'type': 'paleos_unified', 'p_min': 1.0e5, 'p_max': 1.0e12}
+        cache = {}
+        with patch(
+            'zalmoxis.eos.interpolation.load_paleos_unified_table',
+            return_value=rebuilt,
+        ) as mock_load:
+            result = _ensure_unified_cache(eos_file, cache)
+
+        # The unpickle error must not escape; the text loader supplies the entry.
+        mock_load.assert_called_once_with(eos_file)
+        assert result is rebuilt
+        assert cache[eos_file] is rebuilt
+        # The unusable binary cache is replaced on disk by the rebuilt entry.
+        with open(cache_path, 'rb') as f:
+            assert pickle.load(f)['type'] == 'paleos_unified'
+
+    def test_uses_valid_binary_cache_without_text_load(self, tmp_path):
+        """A readable binary cache is returned directly without the slow text load."""
+        from unittest.mock import patch
+
+        from zalmoxis.eos import _ensure_unified_cache
+
+        eos_file = str(tmp_path / 'good_table.dat')
+        cache_path = str(tmp_path / 'good_table.pkl')
+        cached = {'type': 'paleos_unified', 'p_min': 2.0e5, 'p_max': 5.0e11}
+        with open(cache_path, 'wb') as f:
+            pickle.dump(cached, f, protocol=4)
+
+        cache = {}
+        with patch('zalmoxis.eos.interpolation.load_paleos_unified_table') as mock_load:
+            result = _ensure_unified_cache(eos_file, cache)
+
+        # A loadable cache must short-circuit the text rebuild entirely.
+        mock_load.assert_not_called()
+        assert result == cached
+        assert result['p_min'] == pytest.approx(2.0e5)
 
 
 # =====================================================================

--- a/tests/test_eos_functions.py
+++ b/tests/test_eos_functions.py
@@ -332,16 +332,18 @@ class TestEnsureUnifiedCache:
         assert 'density_interp' in result
         assert 'nabla_ad_interp' in result
 
-    def test_rebuilds_when_cache_references_missing_module(self, tmp_path):
+    def test_rebuilds_when_cache_references_missing_module(self, caplog, tmp_path):
         """A binary cache that cannot be unpickled rebuilds from the text table.
 
         A cache pickled by one scipy build embeds the fully-qualified class
         paths of its interpolator objects (and vendored submodules such as
         scipy._lib.array_api_compat). Loading that cache under a scipy build
         that no longer ships those paths raises ModuleNotFoundError, a subclass
-        of ImportError. The loader must treat the binary cache as unusable and
-        rebuild from the authoritative text table instead of propagating.
+        of ImportError. The loader must treat the binary cache as unusable,
+        record why it was rejected, and rebuild from the authoritative text
+        table instead of propagating.
         """
+        import logging
         from unittest.mock import patch
 
         from zalmoxis.eos import _ensure_unified_cache
@@ -359,11 +361,12 @@ class TestEnsureUnifiedCache:
 
         rebuilt = {'type': 'paleos_unified', 'p_min': 1.0e5, 'p_max': 1.0e12}
         cache = {}
-        with patch(
-            'zalmoxis.eos.interpolation.load_paleos_unified_table',
-            return_value=rebuilt,
-        ) as mock_load:
-            result = _ensure_unified_cache(eos_file, cache)
+        with caplog.at_level(logging.INFO, logger='zalmoxis.eos.interpolation'):
+            with patch(
+                'zalmoxis.eos.interpolation.load_paleos_unified_table',
+                return_value=rebuilt,
+            ) as mock_load:
+                result = _ensure_unified_cache(eos_file, cache)
 
         # The unpickle error must not escape; the text loader supplies the entry.
         mock_load.assert_called_once_with(eos_file)
@@ -372,6 +375,12 @@ class TestEnsureUnifiedCache:
         # The unusable binary cache is replaced on disk by the rebuilt entry.
         with open(cache_path, 'rb') as f:
             assert pickle.load(f)['type'] == 'paleos_unified'
+        # The rejection reason is recorded so ops can distinguish a version
+        # mismatch from a corrupt cache: the message names the offending cache
+        # and the concrete exception type, not a generic 'rebuilding' line.
+        assert 'could not be loaded' in caplog.text
+        assert 'ModuleNotFoundError' in caplog.text
+        assert cache_path in caplog.text
 
     def test_uses_valid_binary_cache_without_text_load(self, tmp_path):
         """A readable binary cache is returned directly without the slow text load."""


### PR DESCRIPTION
## Description

The scheduled Zalmoxis nightly fails intermittently across many tests with `ModuleNotFoundError: No module named 'scipy._lib.array_api_compat'`. The push checks ("Zalmoxis tests", "Documentation") stay green; only the nightly breaks, and only on some nights.

The cause is a dependency-resolution race. The nightly installs scipy unpinned, and scipy 1.18.0 dropped the vendored `scipy._lib.array_api_compat` module. The cached PALEOS EOS tables store scipy `RegularGridInterpolator` and `NearestNDInterpolator` objects, whose pickles embed a reference to that module, so loading the cache fails to unpickle whenever the resolver lands on scipy 1.18. On nights where pip picked an older scipy, the cache loaded and the suite passed. The two PALEOS density-test failures are downstream of the same import error (the density lookup catches it and returns `None`), not physics regressions.

This pull request:

- Pins `scipy>=1.14,<1.18` so installs resolve to a release that still ships the vendored module. The lower bound matches what the JAX stack already requires (`scipy>=1.14`), so the bound introduces no new conflict.
- Hardens `_ensure_unified_cache` so an unreadable binary cache rebuilds from the authoritative text table instead of crashing. The loader already rebuilt on `FileNotFoundError`/`EOFError`/`UnpicklingError`; this adds `ImportError` and `AttributeError`, which is the failure shape of a cache written by a different scipy build. A stale cache now degrades to a slower load rather than a hard failure.

## Changes

- `pyproject.toml`: constrain the `scipy` dependency to `>=1.14,<1.18`.
- `src/zalmoxis/eos/interpolation.py`: broaden the cache-load fallback in `_ensure_unified_cache` to rebuild from text on `ImportError`/`AttributeError`.
- `tests/test_eos_functions.py`: add unit tests for the rebuild-from-text path and the direct binary-cache-load path.

## Validation of changes

Test configuration: macOS, Python 3.12, scipy 1.17.1.

- Full unit tier (`pytest -m unit`): 1110 passed, 1 skipped.
- Smoke and integration tiers (`pytest -m "(smoke or integration) and not slow"`): 25 passed, run with the downloaded EOS data.
- The two PALEOS density tests named in the incident (`test_density_at_moderate_conditions`, `test_density_increases_with_pressure`) pass.
- Failure mechanism reproduced directly: a scipy interpolator pickle embeds the class path `scipy._lib.array_api_compat.numpy._aliases`; under a scipy build without that module, `pickle.load` raises `ModuleNotFoundError`, which the broadened `except` now catches and recovers from by rebuilding the table.
- The nightly workflow was dispatched on this branch and passed on CI (run 27915670730), with scipy resolved fresh to 1.17.1 in the real install environment: 1134 passed, 2 skipped, against the prior 25 failed and 14 errored.

## Checklist

- [x] I have followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate (no documentation change needed)
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
