### PR TITLE
Allow the documentation deploy to run on demand

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - main
+  workflow_dispatch:
 permissions:
   contents: read
   pages: write


### PR DESCRIPTION
## Description

Adds a manual `workflow_dispatch` trigger to the documentation workflow so the docs site can be rebuilt from `main` on demand. The automatic build on pushes to `main` is unchanged.

This is useful when a merge commit's push event does not start the deploy and the published site needs to be refreshed without waiting for the next push.

## Validation of changes

Parsed the workflow YAML and confirmed both triggers are present (`push` and `workflow_dispatch`). No job logic changed.

Test configuration: local YAML validation; the workflow runs on ubuntu-latest in CI.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [ ] I have added tests for these changes, as appropriate
- [ ] I have checked that all dependencies have been updated, as required
