### PR TITLE
Keep the Seager water density test from flaking under parallel load

### DIFF
--- a/tests/test_Seager_water.py
+++ b/tests/test_Seager_water.py
@@ -23,14 +23,15 @@ from tools.setup.setup_tests import (
 def test_density_profile_water(cached_solver):
     """Seager-composition water planet rho(r) within 10 % of Seager+2007 at 1 M_earth.
 
-    Population assertion rather than pointwise: requires the bulk of the
-    profile (>=99 % of shells) to fit within 10 % of Seager, with no
-    individual shell drifting beyond 15 %. The pointwise variant was
-    brittle under nightly xdist parallelism: when the inner Picard hits
-    its wall budget ("stuck-bail after 15 iters") on this water config
-    the converged density picks up ~1-2 outlier shells in the 10-15 %
-    band, which is solver drift well inside the physical agreement
-    envelope, not a regression against the Seager reference.
+    Population assertion rather than pointwise: at least 99 % of retained shells
+    must lie within 10 % of the Seager reference and every retained shell within
+    15 %. Layer interfaces (core-mantle, mantle-ice) and vacuum-padding shells
+    are masked out first, because the model grid and the coarsely sampled
+    published Seager curve do not coincide there and would otherwise register a
+    spurious deviation at a single boundary shell. A converged solve matches the
+    reference to a few percent across the retained interior; the population gate
+    holds margin over that while still failing a grossly mis-shaped profile,
+    where a large fraction of shells deviate by tens of percent.
     """
     mass = 1
     data_by_mass = load_Seager_data('radiusdensitySeagerwaterbymass.txt')
@@ -57,11 +58,11 @@ def test_density_profile_water(cached_solver):
     for idx in jump_indices:
         mask[max(0, idx - 3) : min(len(mask), idx + 4)] = False
 
-    # Drop solver vacuum-padding shells. When the inner Picard exhausts its
-    # wall budget on these wide-radius water-world configs, it writes
-    # density=0 for any outer shell whose pressure dropped invalid before
-    # the final converged sweep. Water-ice surface density is ~1500 kg/m^3
-    # so 100 kg/m^3 unambiguously separates a real shell from vacuum pad.
+    # Drop vacuum-padding shells. The radial grid spans the full radius guess,
+    # so the outermost shells can lie beyond the integrated planet surface,
+    # where the structure integration pads density to zero once pressure hits
+    # the P=0 terminal event. Water-ice surface density is ~1500 kg/m^3, so a
+    # 100 kg/m^3 floor cleanly separates a real shell from vacuum padding.
     mask &= model_densities > 100.0
 
     rho_m = model_densities[mask]

--- a/tools/setup/setup_tests.py
+++ b/tools/setup/setup_tests.py
@@ -65,6 +65,17 @@ def run_zalmoxis_rocky_water(id_mass, config_type, cmf, immf, layer_eos_override
     if layer_eos_override:
         config_params['layer_eos_config'] = layer_eos_override
 
+    # Give the analytic Seager solve a generous wall-clock budget. It converges
+    # in tens of seconds, but under pytest-xdist the suite oversubscribes the
+    # CPU and the same solve can take far longer in wall time. At the solver's
+    # 300 s default that contention can trip the wall-clock bail mid-solve and
+    # return an early, non-converged density profile, so the reference
+    # comparisons see a wrong profile instead of the converged one. 3600 s is
+    # far above any contended wall time for this solve yet still bounds a
+    # genuinely stuck one, matching the override the benchmark and JAX suites
+    # already use.
+    config_params['wall_timeout'] = 3600.0
+
     # Create a temporary output file
     suffix = '_rocky.txt' if config_type == 'rocky' else '_water.txt'
     with tempfile.NamedTemporaryFile(delete=False, mode='w', suffix=suffix) as temp_output_file:


### PR DESCRIPTION
## Description

The nightly `tests/test_Seager_water.py::test_density_profile_water` fails intermittently with a roughly 50% density deviation against the Seager+2007 reference, while passing on other runs of the same commit. The 1 M_earth Seager water structure solve is deterministic and converges in tens of seconds, but the suite runs under pytest-xdist, which oversubscribes the CPU. When that contention stretches the solve past the solver's 300 s wall-clock budget, the solver bails mid-solve and returns an early, non-converged density profile, so the reference comparison sees a wrong profile rather than the converged one. The previous docstring attributed this to the inner-Picard iteration bail, but that bail is iteration-based and deterministic and does not fire on the converged solve; the cause is the wall-clock budget alone.

This raises the wall-clock budget for the analytic Seager test solve to 3600 s, far above any wall time the solve can reach even under heavy contention, so it always runs to numerical convergence and the comparison is deterministic. The value matches the budget the benchmark and JAX test paths already use, and keeps a finite ceiling that still bounds a genuinely stuck solve rather than removing the limit entirely. The change is limited to the shared test helper `run_zalmoxis_rocky_water`, so it also covers the rocky and analytic mass-radius tests that solve through the same path. The production solver in `src/` never calls this helper and keeps its 300 s default; the one non-test caller, the analytic-plot tooling in `tools/plots/`, also wants the solve to run to convergence and inherits the longer budget by design. The test docstring and the vacuum-padding comment are also corrected to describe what the test does now.

## Validation of changes

macOS with Python 3.12. I reproduced the failure deterministically by forcing small wall-clock budgets: early truncation freezes a non-converged outer iterate with about 23% total-mass error and gives p99 in the 19-24% range, which confirms wall-clock truncation as the mechanism. The fully converged solve is bit-identical across repeats at p99=4.31% and p100=4.48%, comfortably inside the 10% and 15% gates. After the change, all four affected smoke tests (Seager water, mass-radius water, mass-radius rocky, analytic mass-radius) pass under `pytest -n auto --dist loadfile`, run twice end to end. `ruff check` and `ruff format --check` are clean.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [ ] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
