### PR TITLE
Make the Zalmoxis nightly resilient to runner variance and hangs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,16 +18,18 @@ permissions:
   contents: read
 
 # Nightly: full test suite (unit + smoke + integration) with coverage
-# instrumentation. Targets <60 min wall. Excluded from push and PR CI
-# because each smoke or integration test runs a full Zalmoxis solver
-# call (5-10 min on a 2-vCPU runner under cov instrumentation) and
-# burning that on every push gives no bug-finding signal that the
-# unit suite doesn't already cover.
+# instrumentation. Runs ~50-55 min wall on the shared runners. Excluded
+# from push and PR CI because each smoke or integration test runs a full
+# Zalmoxis solver call (5-10 min on a 2-vCPU runner under cov
+# instrumentation) and burning that on every push gives no bug-finding
+# signal that the unit suite doesn't already cover.
 jobs:
   nightly:
     name: Zalmoxis-nightly (ubuntu-latest)
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # The suite runs ~50-55 min, so a 90 min ceiling leaves wide margin
+    # for shared-runner variance without masking a genuine hang.
+    timeout-minutes: 90
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -48,7 +50,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install .
-          pip install pytest pytest-cov pytest-xdist
+          pip install pytest pytest-cov pytest-xdist pytest-timeout
 
       - name: Cache Zalmoxis EOS data
         id: cache-zalmoxis-data
@@ -64,7 +66,15 @@ jobs:
 
       - name: Run unit + smoke + integration tests with coverage
         run: |
+          # --timeout kills any single hung test after 50 min, failing the
+          # run and naming that test in the worker-crash report while the
+          # other workers still finish, instead of the job ceiling cancelling
+          # the whole run with no clue which test wedged. The slowest healthy
+          # test is ~20 min on the 2-vCPU runner under coverage, so 3000 s
+          # (about 2.4x) absorbs runner variance without risking a false kill.
+          # --durations prints the slowest tests so the profile stays visible.
           pytest -m "(unit or smoke or integration) and not slow" -n auto -o "addopts=" \
+            --timeout=3000 --timeout-method=thread --durations=25 \
             --cov=zalmoxis --cov-report=term-missing --cov-report=xml \
             --cov-fail-under=90
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,7 +262,7 @@ file (enforced by ruff isort).
 - Unit tier: `pytest -o "addopts=" -m unit` (~1.5 min on the dev machine,
   ~1m54s ubuntu / ~2m29s macOS in CI).
 - Nightly tier: `pytest -o "addopts=" -m "(unit or smoke or integration) and not slow"`
-  with coverage; ~46 min on ubuntu CI.
+  with coverage; ~50-55 min on ubuntu CI (90 min job ceiling).
 - The `-o "addopts="` override is needed because `pyproject.toml` defaults to
   `-n auto --dist loadfile` for parallel execution; a single-marker filter run
   is faster without the parallel split.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,7 +261,7 @@ file (enforced by ruff isort).
 - ~1175 tests collected: ~1124 unit, 23 smoke, 2 integration, 44 slow.
 - Unit tier: `pytest -o "addopts=" -m unit` (~1.5 min on the dev machine,
   ~1m54s ubuntu / ~2m29s macOS in CI).
-- Nightly tier: `pytest -o "addopts=" -m "(unit or smoke or integration) and not slow"`
+- Nightly tier: `pytest -o "addopts=" -m "(unit or smoke or integration) and not slow" -n auto`
   with coverage; ~50-55 min on ubuntu CI (90 min job ceiling).
 - The `-o "addopts="` override is needed because `pyproject.toml` defaults to
   `-n auto --dist loadfile` for parallel execution; a single-marker filter run

--- a/docs/Explanations/testing.md
+++ b/docs/Explanations/testing.md
@@ -103,8 +103,8 @@ matrix runs the unit tier without xdist contention on small runners.
 | Trigger | Markers | Budget | Coverage |
 |---|---|---|---|
 | Push / PR (`CI.yml`) | `unit and not slow and not skip` | < 10 min | None (gate pre-flight only) |
-| Nightly cron (`nightly.yml`, 02:00 UTC) | `(unit or smoke or integration) and not slow` | < 60 min | Yes; gates on 90% and uploads to Codecov with the `nightly` flag |
-| Manual `workflow_dispatch` | as above | < 60 min | Yes |
+| Nightly cron (`nightly.yml`, 02:00 UTC) | `(unit or smoke or integration) and not slow` | ~50-55 min (90 min ceiling) | Yes; gates on 90% and uploads to Codecov with the `nightly` flag |
+| Manual `workflow_dispatch` | as above | ~50-55 min (90 min ceiling) | Yes |
 
 Push CI is intentionally unit-only because each smoke or integration test
 runs a full Zalmoxis solver call (5 to 10 min on a 2-vCPU runner under


### PR DESCRIPTION
## Description

The Zalmoxis nightly job kept getting cancelled at its 60-minute wall-clock ceiling even though nothing was actually wrong. The suite genuinely runs about 50 to 55 minutes with coverage, so ordinary shared-runner variance was enough to tip a nearly-finished run over the edge: the scheduled run on 1 July reached 91% before GitHub cancelled it at exactly one hour.

This makes the nightly resilient in three ways:

- Raises the job `timeout-minutes` from 60 to 90 so normal runner variance no longer cancels a nearly-finished run.
- Adds a per-test timeout (`pytest-timeout`, 3000 s) so a genuinely hung test is killed and named in the worker-crash report instead of silently burning the whole job with no clue which test wedged; the other workers still finish.
- Turns on `--durations=25` so the slowest tests are printed into the nightly log every run, which is currently the only way to see the wall-time profile.

It also brings `CLAUDE.md` and `docs/Explanations/testing.md` in line with the real runtime and the new ceiling.

No separate issue; this addresses the cancelled scheduled run 28490522322.

## Validation of changes

I triggered the full nightly on this branch via `workflow_dispatch` (run 28504800952) and it passed: 1181 passed, 2 skipped in 50m43s on ubuntu-latest with Python 3.12.9. That confirms `pytest-timeout` installs and activates cleanly, the new flags are accepted, and no healthy test comes near the per-test limit. The `--durations` output from that run puts the slowest healthy test (`test_rocky_planet_radius_agreement[1]`) at about 21 minutes, so the 3000 s per-test timeout carries roughly a 2.4x margin; because the run was already green at the per-test limit, raising it cannot introduce a new failure. Local environment: macOS with Python 3.12.

One pre-existing marker interaction worth noting: `tests/test_jax_temperature_arrays.py` already carries `@pytest.mark.timeout(600)`, which was inert while `pytest-timeout` was not installed. Installing it here activates that 600 s guard; the test runs well under 160 s in the run above, so it passes comfortably, and per-test markers override the 3000 s global as intended.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [ ] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
