### PR TITLE
Wet and unified mantles on the JAX structure path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,8 +143,13 @@ modes.
 **JAX path (opt-in, `use_jax = True`):** dispatches to `jax_eos/` for the
 inner ODE; the outer and middle loops are unchanged. x64 mode is enabled at
 module import to prevent float32 loss. Parity guarantee: `fast_bilinear_jax`
-agrees with the numpy reference to rtol ≤ 1e-4. Only 2-layer single-component
-configurations are supported on the JAX path; unsupported configs fall back
+agrees with the numpy reference to rtol ≤ 1e-4. Supported on the JAX path:
+2-layer single-component configurations, plus the wet mantle with a
+`VolatileProfile` carrying exactly one active paleos_unified volatile (the
+phi-blended suppressed harmonic mean of `calculate_mixed_density`, ported
+in `jax_eos/rhs.py` under the static `has_volatile` flag). Profiles outside
+that envelope (Chabrier:H with its binodal suppression, multi-volatile,
+`global_miscibility`, `x_interior`) and other unsupported configs fall back
 to numpy automatically.
 
 ## Standalone execution

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,13 +144,17 @@ modes.
 inner ODE; the outer and middle loops are unchanged. x64 mode is enabled at
 module import to prevent float32 loss. Parity guarantee: `fast_bilinear_jax`
 agrees with the numpy reference to rtol ≤ 1e-4. Supported on the JAX path:
-2-layer single-component configurations, plus the wet mantle with a
+2-layer configurations with a paleos_unified core and a mantle in either
+representation, the unified single table (`PALEOS:MgSiO3`, the production
+default; same kernel as the core with the mantle mushy zone factor, static
+`mantle_is_unified` flag) or the 2-phase solid/melted sub-tables
+(`PALEOS-2phase:MgSiO3`, Tdep kernel); plus the wet mantle with a
 `VolatileProfile` carrying exactly one active paleos_unified volatile (the
 phi-blended suppressed harmonic mean of `calculate_mixed_density`, ported
-in `jax_eos/rhs.py` under the static `has_volatile` flag). Profiles outside
-that envelope (Chabrier:H with its binodal suppression, multi-volatile,
-`global_miscibility`, `x_interior`) and other unsupported configs fall back
-to numpy automatically.
+in `jax_eos/rhs.py` under the static `has_volatile` flag) on top of either
+mantle. Profiles outside that envelope (Chabrier:H with its binodal
+suppression, multi-volatile, `global_miscibility`, `x_interior`) and other
+unsupported configs fall back to numpy automatically.
 
 ## Standalone execution
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,7 @@ markers = [
     "smoke: Single-mass solver runs that exercise the full code path with relaxed cost (1 M_earth only)",
     "integration: Real-physics integration tests against published references (PALEOS rocky 1 + 5 M_earth)",
     "slow: Slow convergence tests (minutes, full composition grids)",
+    "physics_invariant: Tests pinning a physical invariant independently of a reference implementation",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,7 @@ markers = [
     "integration: Real-physics integration tests against published references (PALEOS rocky 1 + 5 M_earth)",
     "slow: Slow convergence tests (minutes, full composition grids)",
     "physics_invariant: Tests pinning a physical invariant independently of a reference implementation",
+    "reference_pinned: Tests pinning behavior against a published benchmark, analytical limit, or cross-implementation cross-check (cite the reference in the test docstring)",
 ]
 
 [tool.ruff]

--- a/src/zalmoxis/jax_eos/rhs.py
+++ b/src/zalmoxis/jax_eos/rhs.py
@@ -49,7 +49,7 @@ from .paleos import get_paleos_unified_density_jax
 from .tdep import get_tdep_density_jax
 
 
-@partial(jax.jit, static_argnames=('T_axis_is_radius',))
+@partial(jax.jit, static_argnames=('T_axis_is_radius', 'has_volatile'))
 def coupled_odes_jax(
     radius: jnp.ndarray,
     y: jnp.ndarray,  # shape (3,): [mass, gravity, pressure]
@@ -125,10 +125,48 @@ def coupled_odes_jax(
     log_T_sol_table: jnp.ndarray = None,  # type: ignore[assignment]
     # physical constant G (SI)
     G: float = 6.6743e-11,
+    # --- wet mantle (volatile-blended, has_volatile=True only) ---
+    # One paleos_unified volatile component mixed into the mantle via the
+    # per-shell phi blend of a VolatileProfile: w(phi) = phi * w_liq +
+    # (1 - phi) * w_sol with the LINEAR lever-rule phi of
+    # mixing.compute_melt_fraction (the smoothstep inside the Tdep
+    # kernel is a separate, intra-silicate device). Density is the
+    # suppressed harmonic mean of mixing.calculate_mixed_density with
+    # the same sigmoid weights. All scalars/tables are ignored (and may
+    # stay None) when has_volatile=False; the flag is static so the dry
+    # trace is unchanged.
+    vol_w_liquid: jnp.ndarray = None,  # type: ignore[assignment]
+    vol_w_solid: jnp.ndarray = None,  # type: ignore[assignment]
+    vol_mushy_zone_factor: jnp.ndarray = None,  # type: ignore[assignment]
+    sil_rho_min: float = 322.0,  # condensed-weight sigmoid center, silicate
+    sil_rho_scale: float = 50.0,  # sigmoid width, silicate
+    vol_rho_min: float = 322.0,  # sigmoid center, volatile
+    vol_rho_scale: float = 50.0,  # sigmoid width, volatile
+    vol_density_grid: jnp.ndarray = None,  # type: ignore[assignment]
+    vol_unique_log_p: jnp.ndarray = None,  # type: ignore[assignment]
+    vol_unique_log_t: jnp.ndarray = None,  # type: ignore[assignment]
+    vol_logp_min: float = 0.0,
+    vol_logt_min: float = 0.0,
+    vol_dlog_p: float = 0.0,
+    vol_dlog_t: float = 0.0,
+    vol_n_p: int = 0,
+    vol_n_t: int = 0,
+    vol_p_min: float = 0.0,
+    vol_p_max: float = 0.0,
+    vol_lt_min_per_p: jnp.ndarray = None,  # type: ignore[assignment]
+    vol_lt_max_per_p: jnp.ndarray = None,  # type: ignore[assignment]
+    vol_liquidus_log_p: jnp.ndarray = None,  # type: ignore[assignment]
+    vol_liquidus_log_t: jnp.ndarray = None,  # type: ignore[assignment]
+    vol_liquidus_min_log_p: float = 0.0,
+    vol_liquidus_max_log_p: float = 0.0,
+    vol_has_liquidus_f: jnp.ndarray = None,  # type: ignore[assignment]
     # Temperature-axis convention (static, selects P- vs r-indexed branch).
     # Kept at the end of the signature so older callers that rely on the
     # positional order of the EOS-cache args are not affected.
     T_axis_is_radius: bool = False,
+    # Wet-mantle flag (static). True adds the volatile blend to the
+    # mantle density; False reproduces the dry trace exactly.
+    has_volatile: bool = False,
 ):
     """Return dy/dr = [dM/dr, dg/dr, dP/dr] at (radius, y)."""
     mass, gravity, pressure = y[0], y[1], y[2]
@@ -224,6 +262,85 @@ def coupled_odes_jax(
         liq_lt_min_per_p,
         liq_lt_max_per_p,
     )
+
+    if has_volatile:
+        # Wet mantle: blend one volatile into the silicate density,
+        # mirroring mixing.calculate_mixed_density with a
+        # VolatileProfile. The blend phi is the LINEAR lever rule of
+        # mixing.compute_melt_fraction (clamped [0, 1]; degenerate
+        # T_liq <= T_sol maps to a step at T_sol; invalid curves map
+        # to 0.5), distinct from the smoothstep used inside the Tdep
+        # silicate kernel.
+        melt_valid = jnp.isfinite(T_sol) & jnp.isfinite(T_liq)
+        safe_dT_blend = jnp.where(T_liq > T_sol, T_liq - T_sol, 1.0)
+        phi_linear = jnp.clip((temperature - T_sol) / safe_dT_blend, 0.0, 1.0)
+        phi_degen = jnp.where(temperature > T_sol, 1.0, 0.0)
+        phi = jnp.where(
+            melt_valid,
+            jnp.where(T_liq > T_sol, phi_linear, phi_degen),
+            0.5,
+        )
+
+        # VolatileProfile.blend: volatile fraction from the phi blend,
+        # silicate takes the remainder (fractions already sum to 1).
+        w_vol = phi * vol_w_liquid + (1.0 - phi) * vol_w_solid
+        w_sil = jnp.maximum(0.0, 1.0 - w_vol)
+
+        rho_vol = get_paleos_unified_density_jax(
+            pressure,
+            temperature,
+            vol_mushy_zone_factor,
+            vol_density_grid,
+            vol_unique_log_p,
+            vol_unique_log_t,
+            vol_logp_min,
+            vol_logt_min,
+            vol_dlog_p,
+            vol_dlog_t,
+            vol_n_p,
+            vol_n_t,
+            vol_p_min,
+            vol_p_max,
+            vol_lt_min_per_p,
+            vol_lt_max_per_p,
+            vol_liquidus_log_p,
+            vol_liquidus_log_t,
+            vol_liquidus_min_log_p,
+            vol_liquidus_max_log_p,
+            vol_has_liquidus_f,
+        )
+
+        # Suppressed harmonic mean (mixing.calculate_mixed_density):
+        # each component weighted by w_i * sigmoid(rho_i), gas-like
+        # densities suppressed. The arg clamp matches _condensed_weight.
+        # numpy semantics preserved: a component with w_i <= 0 is
+        # skipped before its density is even consulted; a component
+        # with w_i > 0 but invalid density aborts the whole mixture
+        # (None in numpy, NaN here, zeroed RHS below). Safe substitutes
+        # keep the discarded lanes of the trace NaN-free.
+        def _condensed_weight_jax(rho_i, rho_min, rho_scale):
+            arg = jnp.clip(-(rho_i - rho_min) / rho_scale, -500.0, 500.0)
+            return 1.0 / (1.0 + jnp.exp(arg))
+
+        vol_ok = jnp.isfinite(rho_vol) & (rho_vol > 0.0)
+        sil_ok = jnp.isfinite(rho_mantle) & (rho_mantle > 0.0)
+        vol_active = w_vol > 0.0
+        sil_active = w_sil > 0.0
+        rho_vol_safe = jnp.where(vol_ok, rho_vol, 1.0)
+        rho_sil_safe = jnp.where(sil_ok, rho_mantle, 1.0)
+        sigma_sil = _condensed_weight_jax(rho_sil_safe, sil_rho_min, sil_rho_scale)
+        sigma_vol = _condensed_weight_jax(rho_vol_safe, vol_rho_min, vol_rho_scale)
+        w_eff_sil = jnp.where(sil_active, w_sil * sigma_sil, 0.0)
+        w_eff_vol = jnp.where(vol_active, w_vol * sigma_vol, 0.0)
+        w_eff_sum = w_eff_sil + w_eff_vol
+        inv_rho_sum = w_eff_sil / rho_sil_safe + w_eff_vol / rho_vol_safe
+        mix_ok = (
+            (sil_ok | ~sil_active)
+            & (vol_ok | ~vol_active)
+            & (w_eff_sum > 0.0)
+            & (inv_rho_sum > 0.0)
+        )
+        rho_mantle = jnp.where(mix_ok, w_eff_sum / inv_rho_sum, jnp.nan)
 
     # Layer selection
     rho = jnp.where(mass < cmb_mass, rho_core, rho_mantle)

--- a/src/zalmoxis/jax_eos/rhs.py
+++ b/src/zalmoxis/jax_eos/rhs.py
@@ -49,7 +49,7 @@ from .paleos import get_paleos_unified_density_jax
 from .tdep import get_tdep_density_jax
 
 
-@partial(jax.jit, static_argnames=('T_axis_is_radius', 'has_volatile'))
+@partial(jax.jit, static_argnames=('T_axis_is_radius', 'has_volatile', 'mantle_is_unified'))
 def coupled_odes_jax(
     radius: jnp.ndarray,
     y: jnp.ndarray,  # shape (3,): [mass, gravity, pressure]
@@ -79,32 +79,60 @@ def coupled_odes_jax(
     core_liquidus_max_log_p: float,
     core_has_liquidus_f: jnp.ndarray,
     # --- mantle Tdep (solid + liquid sub-tables + melting curves) ---
-    sol_density_grid: jnp.ndarray,
-    sol_unique_log_p: jnp.ndarray,
-    sol_unique_log_t: jnp.ndarray,
-    sol_logp_min: float,
-    sol_logt_min: float,
-    sol_dlog_p: float,
-    sol_dlog_t: float,
-    sol_n_p: int,
-    sol_n_t: int,
-    sol_p_min: float,
-    sol_p_max: float,
-    sol_lt_min_per_p: jnp.ndarray,
-    sol_lt_max_per_p: jnp.ndarray,
-    liq_density_grid: jnp.ndarray,
-    liq_unique_log_p: jnp.ndarray,
-    liq_unique_log_t: jnp.ndarray,
-    liq_logp_min: float,
-    liq_logt_min: float,
-    liq_dlog_p: float,
-    liq_dlog_t: float,
-    liq_n_p: int,
-    liq_n_t: int,
-    liq_p_min: float,
-    liq_p_max: float,
-    liq_lt_min_per_p: jnp.ndarray,
-    liq_lt_max_per_p: jnp.ndarray,
+    # Unused (and omittable) when mantle_is_unified=True; the static flag
+    # keeps the untraced branch off the compiled graph.
+    sol_density_grid: jnp.ndarray = None,  # type: ignore[assignment]
+    sol_unique_log_p: jnp.ndarray = None,  # type: ignore[assignment]
+    sol_unique_log_t: jnp.ndarray = None,  # type: ignore[assignment]
+    sol_logp_min: float = 0.0,
+    sol_logt_min: float = 0.0,
+    sol_dlog_p: float = 0.0,
+    sol_dlog_t: float = 0.0,
+    sol_n_p: int = 0,
+    sol_n_t: int = 0,
+    sol_p_min: float = 0.0,
+    sol_p_max: float = 0.0,
+    sol_lt_min_per_p: jnp.ndarray = None,  # type: ignore[assignment]
+    sol_lt_max_per_p: jnp.ndarray = None,  # type: ignore[assignment]
+    liq_density_grid: jnp.ndarray = None,  # type: ignore[assignment]
+    liq_unique_log_p: jnp.ndarray = None,  # type: ignore[assignment]
+    liq_unique_log_t: jnp.ndarray = None,  # type: ignore[assignment]
+    liq_logp_min: float = 0.0,
+    liq_logt_min: float = 0.0,
+    liq_dlog_p: float = 0.0,
+    liq_dlog_t: float = 0.0,
+    liq_n_p: int = 0,
+    liq_n_t: int = 0,
+    liq_p_min: float = 0.0,
+    liq_p_max: float = 0.0,
+    liq_lt_min_per_p: jnp.ndarray = None,  # type: ignore[assignment]
+    liq_lt_max_per_p: jnp.ndarray = None,  # type: ignore[assignment]
+    # --- mantle unified (single PALEOS table, mantle_is_unified=True) ---
+    # Same table anatomy as the core; consumed by
+    # get_paleos_unified_density_jax with the mantle's mushy zone factor
+    # (the unified path derives its solidus internally from the table's
+    # own liquidus, mirroring eos/paleos.get_paleos_unified_density; the
+    # external melting-curve tables below are NOT consulted for density,
+    # only for the wet blend's phi).
+    mushy_zone_factor_mantle: jnp.ndarray = None,  # type: ignore[assignment]
+    mun_density_grid: jnp.ndarray = None,  # type: ignore[assignment]
+    mun_unique_log_p: jnp.ndarray = None,  # type: ignore[assignment]
+    mun_unique_log_t: jnp.ndarray = None,  # type: ignore[assignment]
+    mun_logp_min: float = 0.0,
+    mun_logt_min: float = 0.0,
+    mun_dlog_p: float = 0.0,
+    mun_dlog_t: float = 0.0,
+    mun_n_p: int = 0,
+    mun_n_t: int = 0,
+    mun_p_min: float = 0.0,
+    mun_p_max: float = 0.0,
+    mun_lt_min_per_p: jnp.ndarray = None,  # type: ignore[assignment]
+    mun_lt_max_per_p: jnp.ndarray = None,  # type: ignore[assignment]
+    mun_liquidus_log_p: jnp.ndarray = None,  # type: ignore[assignment]
+    mun_liquidus_log_t: jnp.ndarray = None,  # type: ignore[assignment]
+    mun_liquidus_min_log_p: float = 0.0,
+    mun_liquidus_max_log_p: float = 0.0,
+    mun_has_liquidus_f: jnp.ndarray = None,  # type: ignore[assignment]
     # Mantle liquidus and solidus tabulated on a UNIFORM log10(P [Pa])
     # axis as ``log10(T)`` values. The wrapper samples
     # ``log10(liquidus_func(P))`` and ``log10(solidus_func(P))`` on the
@@ -167,6 +195,11 @@ def coupled_odes_jax(
     # Wet-mantle flag (static). True adds the volatile blend to the
     # mantle density; False reproduces the dry trace exactly.
     has_volatile: bool = False,
+    # Mantle-representation flag (static). False: PALEOS-2phase solid +
+    # melted sub-tables through the Tdep kernel (the original path).
+    # True: single unified PALEOS table through the same kernel the core
+    # uses.
+    mantle_is_unified: bool = False,
 ):
     """Return dy/dr = [dM/dr, dg/dr, dP/dr] at (radius, y)."""
     mass, gravity, pressure = y[0], y[1], y[2]
@@ -229,39 +262,68 @@ def coupled_odes_jax(
         core_has_liquidus_f,
     )
 
-    # Mantle density (Tdep 2-phase)
-    rho_mantle = get_tdep_density_jax(
-        pressure,
-        temperature,
-        T_sol,
-        T_liq,
-        sol_density_grid,
-        sol_unique_log_p,
-        sol_unique_log_t,
-        sol_logp_min,
-        sol_logt_min,
-        sol_dlog_p,
-        sol_dlog_t,
-        sol_n_p,
-        sol_n_t,
-        sol_p_min,
-        sol_p_max,
-        sol_lt_min_per_p,
-        sol_lt_max_per_p,
-        liq_density_grid,
-        liq_unique_log_p,
-        liq_unique_log_t,
-        liq_logp_min,
-        liq_logt_min,
-        liq_dlog_p,
-        liq_dlog_t,
-        liq_n_p,
-        liq_n_t,
-        liq_p_min,
-        liq_p_max,
-        liq_lt_min_per_p,
-        liq_lt_max_per_p,
-    )
+    # Mantle density: unified single table (same kernel as the core, its
+    # solidus derived internally from the table's own liquidus and the
+    # mantle mushy zone factor) or Tdep 2-phase (solid + melted
+    # sub-tables blended through the external melting-curve tables). The
+    # static flag keeps only the selected branch in the compiled graph.
+    if mantle_is_unified:
+        rho_mantle = get_paleos_unified_density_jax(
+            pressure,
+            temperature,
+            mushy_zone_factor_mantle,
+            mun_density_grid,
+            mun_unique_log_p,
+            mun_unique_log_t,
+            mun_logp_min,
+            mun_logt_min,
+            mun_dlog_p,
+            mun_dlog_t,
+            mun_n_p,
+            mun_n_t,
+            mun_p_min,
+            mun_p_max,
+            mun_lt_min_per_p,
+            mun_lt_max_per_p,
+            mun_liquidus_log_p,
+            mun_liquidus_log_t,
+            mun_liquidus_min_log_p,
+            mun_liquidus_max_log_p,
+            mun_has_liquidus_f,
+        )
+    else:
+        rho_mantle = get_tdep_density_jax(
+            pressure,
+            temperature,
+            T_sol,
+            T_liq,
+            sol_density_grid,
+            sol_unique_log_p,
+            sol_unique_log_t,
+            sol_logp_min,
+            sol_logt_min,
+            sol_dlog_p,
+            sol_dlog_t,
+            sol_n_p,
+            sol_n_t,
+            sol_p_min,
+            sol_p_max,
+            sol_lt_min_per_p,
+            sol_lt_max_per_p,
+            liq_density_grid,
+            liq_unique_log_p,
+            liq_unique_log_t,
+            liq_logp_min,
+            liq_logt_min,
+            liq_dlog_p,
+            liq_dlog_t,
+            liq_n_p,
+            liq_n_t,
+            liq_p_min,
+            liq_p_max,
+            liq_lt_min_per_p,
+            liq_lt_max_per_p,
+        )
 
     if has_volatile:
         # Wet mantle: blend one volatile into the silicate density,

--- a/src/zalmoxis/jax_eos/solver.py
+++ b/src/zalmoxis/jax_eos/solver.py
@@ -39,10 +39,11 @@ def _build_diffeqsolve_jit(
 
     Must be top-level so jax.jit can cache the compiled kernel across
     wrapper calls. Closure over diffrax so the numpy-path import cost
-    stays zero. ``T_axis_is_radius`` and ``has_volatile`` are closed
-    over (not traced args) so the corresponding branches of
-    ``coupled_odes_jax`` are specialised at compile time. A separate
-    compiled variant is cached per flag triple in ``_SOLVE_CACHE`` below.
+    stays zero. ``T_axis_is_radius``, ``has_volatile``, and
+    ``mantle_is_unified`` are closed over (not traced args) so the
+    corresponding branches of ``coupled_odes_jax`` are specialised at
+    compile time. A separate compiled variant is cached per flag triple
+    in ``_SOLVE_CACHE`` below.
     """
     import diffrax
     import optimistix as optx

--- a/src/zalmoxis/jax_eos/solver.py
+++ b/src/zalmoxis/jax_eos/solver.py
@@ -32,24 +32,26 @@ import jax.numpy as jnp
 from .rhs import coupled_odes_jax
 
 
-def _build_diffeqsolve_jit(T_axis_is_radius: bool):
+def _build_diffeqsolve_jit(T_axis_is_radius: bool, has_volatile: bool = False):
     """Build a jitted diffeqsolve closure for one axis convention.
 
     Must be top-level so jax.jit can cache the compiled kernel across
     wrapper calls. Closure over diffrax so the numpy-path import cost
-    stays zero. ``T_axis_is_radius`` is closed over (not a traced arg)
-    so the corresponding branch of ``coupled_odes_jax`` is specialised
-    at compile time. A separate compiled variant is cached per flag
-    value in ``_SOLVE_CACHE`` below.
+    stays zero. ``T_axis_is_radius`` and ``has_volatile`` are closed
+    over (not traced args) so the corresponding branches of
+    ``coupled_odes_jax`` are specialised at compile time. A separate
+    compiled variant is cached per flag pair in ``_SOLVE_CACHE`` below.
     """
     import diffrax
     import optimistix as optx
 
     def _ode_rhs(t, y, args):
-        # T_axis_is_radius is closed over (not in args) so it stays
+        # The static flags are closed over (not in args) so they stay
         # static for JIT; this keeps coupled_odes_jax single-variant
         # per _solve closure.
-        return coupled_odes_jax(t, y, T_axis_is_radius=T_axis_is_radius, **args)
+        return coupled_odes_jax(
+            t, y, T_axis_is_radius=T_axis_is_radius, has_volatile=has_volatile, **args
+        )
 
     def _pressure_cond(t, y, args, **kwargs):
         # Event fires when pressure crosses zero. direction=False tells
@@ -94,14 +96,15 @@ def _build_diffeqsolve_jit(T_axis_is_radius: bool):
     return _solve
 
 
-# Separate compiled closure per temperature-axis convention.
-_SOLVE_CACHE: dict[bool, object] = {}
+# Separate compiled closure per (temperature-axis, wet-mantle) pair.
+_SOLVE_CACHE: dict[tuple[bool, bool], object] = {}
 
 
-def _get_solve(T_axis_is_radius: bool):
-    if T_axis_is_radius not in _SOLVE_CACHE:
-        _SOLVE_CACHE[T_axis_is_radius] = _build_diffeqsolve_jit(T_axis_is_radius)
-    return _SOLVE_CACHE[T_axis_is_radius]
+def _get_solve(T_axis_is_radius: bool, has_volatile: bool = False):
+    key = (T_axis_is_radius, has_volatile)
+    if key not in _SOLVE_CACHE:
+        _SOLVE_CACHE[key] = _build_diffeqsolve_jit(T_axis_is_radius, has_volatile)
+    return _SOLVE_CACHE[key]
 
 
 def solve_structure_jax(
@@ -110,6 +113,7 @@ def solve_structure_jax(
     rtol=1e-5,
     atol=1e-6,
     T_axis_is_radius: bool = False,
+    has_volatile: bool = False,
     **rhs_kwargs,
 ):
     """Integrate the structure ODE from radii[0] to radii[-1].
@@ -137,7 +141,7 @@ def solve_structure_jax(
     ys : array of shape (n_layers, 3)
         State [M, g, P] at each radii.
     """
-    solve = _get_solve(T_axis_is_radius)
+    solve = _get_solve(T_axis_is_radius, has_volatile)
     return solve(
         jnp.asarray(radii, dtype=jnp.float64),
         jnp.asarray(y0, dtype=jnp.float64),

--- a/src/zalmoxis/jax_eos/solver.py
+++ b/src/zalmoxis/jax_eos/solver.py
@@ -42,7 +42,7 @@ def _build_diffeqsolve_jit(
     stays zero. ``T_axis_is_radius`` and ``has_volatile`` are closed
     over (not traced args) so the corresponding branches of
     ``coupled_odes_jax`` are specialised at compile time. A separate
-    compiled variant is cached per flag pair in ``_SOLVE_CACHE`` below.
+    compiled variant is cached per flag triple in ``_SOLVE_CACHE`` below.
     """
     import diffrax
     import optimistix as optx

--- a/src/zalmoxis/jax_eos/solver.py
+++ b/src/zalmoxis/jax_eos/solver.py
@@ -32,7 +32,9 @@ import jax.numpy as jnp
 from .rhs import coupled_odes_jax
 
 
-def _build_diffeqsolve_jit(T_axis_is_radius: bool, has_volatile: bool = False):
+def _build_diffeqsolve_jit(
+    T_axis_is_radius: bool, has_volatile: bool = False, mantle_is_unified: bool = False
+):
     """Build a jitted diffeqsolve closure for one axis convention.
 
     Must be top-level so jax.jit can cache the compiled kernel across
@@ -50,7 +52,12 @@ def _build_diffeqsolve_jit(T_axis_is_radius: bool, has_volatile: bool = False):
         # static for JIT; this keeps coupled_odes_jax single-variant
         # per _solve closure.
         return coupled_odes_jax(
-            t, y, T_axis_is_radius=T_axis_is_radius, has_volatile=has_volatile, **args
+            t,
+            y,
+            T_axis_is_radius=T_axis_is_radius,
+            has_volatile=has_volatile,
+            mantle_is_unified=mantle_is_unified,
+            **args,
         )
 
     def _pressure_cond(t, y, args, **kwargs):
@@ -96,14 +103,19 @@ def _build_diffeqsolve_jit(T_axis_is_radius: bool, has_volatile: bool = False):
     return _solve
 
 
-# Separate compiled closure per (temperature-axis, wet-mantle) pair.
-_SOLVE_CACHE: dict[tuple[bool, bool], object] = {}
+# Separate compiled closure per (temperature-axis, wet-mantle,
+# mantle-representation) triple.
+_SOLVE_CACHE: dict[tuple[bool, bool, bool], object] = {}
 
 
-def _get_solve(T_axis_is_radius: bool, has_volatile: bool = False):
-    key = (T_axis_is_radius, has_volatile)
+def _get_solve(
+    T_axis_is_radius: bool, has_volatile: bool = False, mantle_is_unified: bool = False
+):
+    key = (T_axis_is_radius, has_volatile, mantle_is_unified)
     if key not in _SOLVE_CACHE:
-        _SOLVE_CACHE[key] = _build_diffeqsolve_jit(T_axis_is_radius, has_volatile)
+        _SOLVE_CACHE[key] = _build_diffeqsolve_jit(
+            T_axis_is_radius, has_volatile, mantle_is_unified
+        )
     return _SOLVE_CACHE[key]
 
 
@@ -114,6 +126,7 @@ def solve_structure_jax(
     atol=1e-6,
     T_axis_is_radius: bool = False,
     has_volatile: bool = False,
+    mantle_is_unified: bool = False,
     **rhs_kwargs,
 ):
     """Integrate the structure ODE from radii[0] to radii[-1].
@@ -141,7 +154,7 @@ def solve_structure_jax(
     ys : array of shape (n_layers, 3)
         State [M, g, P] at each radii.
     """
-    solve = _get_solve(T_axis_is_radius, has_volatile)
+    solve = _get_solve(T_axis_is_radius, has_volatile, mantle_is_unified)
     return solve(
         jnp.asarray(radii, dtype=jnp.float64),
         jnp.asarray(y0, dtype=jnp.float64),

--- a/src/zalmoxis/jax_eos/wrapper.py
+++ b/src/zalmoxis/jax_eos/wrapper.py
@@ -120,6 +120,43 @@ def _tabulate_adiabat(radii, temperature_function, n_pts=4000):
     return log_p_grid, T_values
 
 
+def _validate_wet_mantle(volatile_profile, mantle_lm, material_dictionaries):
+    """Check a VolatileProfile against the JAX wet-mantle envelope.
+
+    Supported: exactly one active volatile, paleos_unified format, no
+    binodal physics (Chabrier:H needs the H2 suppression factor, which
+    is not ported), no global miscibility, no x_interior. Anything else
+    raises ValueError so the caller falls back to the numpy path.
+
+    Returns (vol_eos_name, (w_liquid, w_solid)).
+    """
+    if getattr(volatile_profile, 'global_miscibility', False):
+        raise ValueError('JAX wet path does not support global_miscibility profiles')
+    if getattr(volatile_profile, 'x_interior', None):
+        raise ValueError('JAX wet path does not support x_interior profiles')
+
+    active = {}
+    for key in set(volatile_profile.w_liquid) | set(volatile_profile.w_solid):
+        w_l = float(volatile_profile.w_liquid.get(key, 0.0))
+        w_s = float(volatile_profile.w_solid.get(key, 0.0))
+        if (w_l > 0.0 or w_s > 0.0) and key in mantle_lm.components:
+            active[key] = (w_l, w_s)
+    if len(active) != 1:
+        raise ValueError(
+            'JAX wet path supports exactly one active volatile in the '
+            f'mantle mixture, got {sorted(active) or "none"}'
+        )
+    ((vol_eos, scalars),) = active.items()
+    if vol_eos == 'Chabrier:H':
+        raise ValueError(
+            'JAX wet path does not support Chabrier:H (binodal suppression not ported)'
+        )
+    vol_mat = material_dictionaries.get(vol_eos)
+    if vol_mat is None:
+        raise ValueError(f'JAX wet path: no material entry for {vol_eos!r}')
+    return vol_eos, scalars
+
+
 def solve_structure_via_jax(
     layer_mixtures,
     cmb_mass,
@@ -137,9 +174,10 @@ def solve_structure_via_jax(
     temperature_function=None,
     temperature_arrays=None,  # (r_arr, T_arr): r-indexed T profile
     mushy_zone_factors=None,
-    condensed_rho_min=None,  # ignored (JAX path assumes no multi-component mixing)
+    condensed_rho_min=None,  # sigmoid center for the wet-mantle harmonic mean
     condensed_rho_scale=None,
     binodal_T_scale=None,
+    volatile_profile=None,  # VolatileProfile: single-volatile wet mantle
 ):
     """Drop-in replacement for ``solve_structure`` using the JAX path.
 
@@ -202,9 +240,31 @@ def solve_structure_via_jax(
         )
     core_cached = _ensure_unified_cache(core_mat['eos_file'], interpolation_cache)
 
-    # Mantle cache: PALEOS-2phase (solid + melted sub-tables)
+    # Mantle components. The dry path requires a single-component
+    # mantle; a multi-component mixture without a profile has no JAX
+    # implementation of the uniform-spread harmonic mean, and silently
+    # taking components[0] would drop the other components' mass, so
+    # reject it (numpy fallback). With a VolatileProfile, exactly one
+    # paleos_unified volatile is supported alongside the Tdep silicate.
     mantle_lm = layer_mixtures['mantle']
-    mantle_eos = mantle_lm.components[0]
+    vol_eos = None
+    if volatile_profile is not None:
+        vol_eos, vol_scalars = _validate_wet_mantle(
+            volatile_profile, mantle_lm, material_dictionaries
+        )
+        mantle_eos = volatile_profile.primary_component
+        if mantle_eos not in mantle_lm.components:
+            raise ValueError(
+                'JAX wet path: profile primary component '
+                f'{mantle_eos!r} not in mantle mixture {mantle_lm.components!r}'
+            )
+    else:
+        if len(mantle_lm.components) != 1:
+            raise ValueError(
+                'JAX path requires a single-component mantle without a '
+                f'volatile profile, got {mantle_lm.components!r}'
+            )
+        mantle_eos = mantle_lm.components[0]
     mantle_mat = material_dictionaries[mantle_eos]
     if '_api_resolved' not in mantle_mat:
         if _is_paleos_api(
@@ -225,6 +285,24 @@ def solve_structure_via_jax(
     liq_file = mantle_mat['melted_mantle']['eos_file']
     sol_cached = interpolation_cache[sol_file]
     liq_cached = interpolation_cache[liq_file]
+
+    # Volatile cache (wet mantle only): paleos_unified, same extraction
+    # as the core. Resolve the PALEOS-API entry lazily like the others.
+    vol_cached = None
+    if vol_eos is not None:
+        vol_mat = material_dictionaries[vol_eos]
+        if '_api_resolved' not in vol_mat:
+            if _is_paleos_api(vol_mat):
+                from ..eos.paleos_api_cache import resolve_registry_entry
+
+                resolve_registry_entry(vol_mat)
+            vol_mat['_api_resolved'] = True
+        if vol_mat.get('format') != 'paleos_unified':
+            raise ValueError(
+                f'JAX wet path requires a paleos_unified volatile, got '
+                f'format {vol_mat.get("format")!r} for {vol_eos!r}'
+            )
+        vol_cached = _ensure_unified_cache(vol_mat['eos_file'], interpolation_cache)
 
     # mushy_zone_factor for the CORE (paleos_unified takes one; mantle uses Tdep
     # which handles its own solid/liquid separately).
@@ -363,6 +441,46 @@ def solve_structure_via_jax(
     jax_args.update(_extract_sub_args(liq_cached, 'liq'))
     jax_args.update(melt_curves)
 
+    has_volatile = vol_cached is not None
+    if has_volatile:
+        from ..mixing import (
+            _COMPONENT_RHO_MIN,
+            _COMPONENT_RHO_SCALE,
+            CONDENSED_RHO_MIN_DEFAULT,
+            CONDENSED_RHO_SCALE_DEFAULT,
+            _get_mushy_zone_factor,
+        )
+
+        # Sigmoid centers and widths exactly as calculate_mixed_density
+        # resolves them: per-component override, else the config value,
+        # else the mixing-module default.
+        _rho_min_cfg = (
+            float(condensed_rho_min)
+            if condensed_rho_min is not None
+            else CONDENSED_RHO_MIN_DEFAULT
+        )
+        _rho_scale_cfg = (
+            float(condensed_rho_scale)
+            if condensed_rho_scale is not None
+            else CONDENSED_RHO_SCALE_DEFAULT
+        )
+        w_liq_v, w_sol_v = vol_scalars
+        jax_args.update(_extract_sub_args(vol_cached, 'vol'))
+        jax_args.update(_extract_liquidus(vol_cached, 'vol'))
+        jax_args.update(
+            {
+                'vol_w_liquid': float(w_liq_v),
+                'vol_w_solid': float(w_sol_v),
+                'vol_mushy_zone_factor': float(
+                    _get_mushy_zone_factor(vol_eos, mushy_zone_factors)
+                ),
+                'sil_rho_min': _COMPONENT_RHO_MIN.get(mantle_eos, _rho_min_cfg),
+                'sil_rho_scale': _COMPONENT_RHO_SCALE.get(mantle_eos, _rho_scale_cfg),
+                'vol_rho_min': _COMPONENT_RHO_MIN.get(vol_eos, _rho_min_cfg),
+                'vol_rho_scale': _COMPONENT_RHO_SCALE.get(vol_eos, _rho_scale_cfg),
+            }
+        )
+
     global _CALL_COUNT, _TOTAL_WALL
     _CALL_COUNT += 1
     _t0 = _time.perf_counter()
@@ -372,6 +490,7 @@ def solve_structure_via_jax(
         rtol=float(relative_tolerance),
         atol=float(absolute_tolerance),
         T_axis_is_radius=T_axis_is_radius,
+        has_volatile=has_volatile,
         **jax_args,
     )
     # np.asarray on a jnp.ndarray yields a read-only view of the JAX

--- a/src/zalmoxis/jax_eos/wrapper.py
+++ b/src/zalmoxis/jax_eos/wrapper.py
@@ -5,10 +5,14 @@
 (mass, gravity, pressure) output arrays, but routes through the
 JIT-compiled JAX path.
 
-Scope: Stage-1b 2-layer config (single-component core + mantle,
-PALEOS:iron + PALEOS-2phase:MgSiO3). Anything outside this envelope
-(3-layer ice, multi-component mixing, non-Stixrude14 melting) falls
-back to the numpy path at the caller (solver._solve).
+Scope: 2-layer config with a paleos_unified core (PALEOS:iron) and a
+mantle in either representation: the unified single table
+(PALEOS:MgSiO3, the production default) or the 2-phase solid/melted
+sub-tables (PALEOS-2phase:MgSiO3). A wet mantle (VolatileProfile with
+one paleos_unified volatile) is supported on top of either. Anything
+outside this envelope (3-layer ice, uniform-spread multi-component
+mixing, H2 profiles) falls back to the numpy path at the caller
+(solver._solve).
 
 The wrapper does three things per call:
  1. Extract cache contents into flat arrays the JIT function needs.
@@ -274,17 +278,37 @@ def solve_structure_via_jax(
 
             resolve_registry_entry(mantle_mat)
         mantle_mat['_api_resolved'] = True
-    if 'melted_mantle' not in mantle_mat or 'solid_mantle' not in mantle_mat:
+    # Two supported mantle representations. Unified: a single PALEOS
+    # table (the production default), consumed by the same kernel as the
+    # core with the mantle's mushy zone factor; its solidus derives
+    # internally from the table's own liquidus, so the external melting
+    # curves below matter only for the wet blend's phi. 2-phase: solid +
+    # melted sub-tables through the Tdep kernel.
+    mantle_is_unified = mantle_mat.get('format') == 'paleos_unified'
+    sol_cached = liq_cached = mantle_cached = None
+    if mantle_is_unified:
+        _mantle_file = mantle_mat.get('eos_file')
+        if not _mantle_file:
+            # Raise ValueError, not KeyError: the caller's numpy
+            # fallback only catches ValueError.
+            raise ValueError(
+                f'paleos_unified mantle entry for {mantle_eos!r} carries no eos_file'
+            )
+        mantle_cached = _ensure_unified_cache(_mantle_file, interpolation_cache)
+    elif 'melted_mantle' in mantle_mat and 'solid_mantle' in mantle_mat:
+        # Lazy-load both sub-tables via numpy's get_tabulated_eos
+        _ = get_tabulated_eos(1e10, mantle_mat, 'solid_mantle', 3000.0, interpolation_cache)
+        _ = get_tabulated_eos(1e10, mantle_mat, 'melted_mantle', 5000.0, interpolation_cache)
+        sol_file = mantle_mat['solid_mantle']['eos_file']
+        liq_file = mantle_mat['melted_mantle']['eos_file']
+        sol_cached = interpolation_cache[sol_file]
+        liq_cached = interpolation_cache[liq_file]
+    else:
         raise ValueError(
-            'JAX path requires PALEOS-2phase mantle with solid_mantle+melted_mantle'
+            'JAX path requires a paleos_unified mantle or a PALEOS-2phase '
+            'mantle with solid_mantle+melted_mantle, got format '
+            f'{mantle_mat.get("format")!r} for {mantle_eos!r}'
         )
-    # Lazy-load both sub-tables via numpy's get_tabulated_eos
-    _ = get_tabulated_eos(1e10, mantle_mat, 'solid_mantle', 3000.0, interpolation_cache)
-    _ = get_tabulated_eos(1e10, mantle_mat, 'melted_mantle', 5000.0, interpolation_cache)
-    sol_file = mantle_mat['solid_mantle']['eos_file']
-    liq_file = mantle_mat['melted_mantle']['eos_file']
-    sol_cached = interpolation_cache[sol_file]
-    liq_cached = interpolation_cache[liq_file]
 
     # Volatile cache (wet mantle only): paleos_unified, same extraction
     # as the core. Resolve the PALEOS-API entry lazily like the others.
@@ -397,9 +421,33 @@ def solve_structure_via_jax(
     # time, which dominates coupled-solve wall time.
     # Cache key uses object id; the dict cap prevents unbounded growth from
     # unique-per-call closures (rare).
+    # Missing melting curves are legitimate for an all-unified config
+    # (the unified density derives its solidus internally, and Zalmoxis'
+    # loader returns None for such configs). Mirror numpy: NaN tables
+    # make the RHS's melt-curve lookup non-finite, which routes the wet
+    # blend's phi to the same 0.5 fallback compute_melt_fraction uses
+    # for None curves. The 2-phase Tdep mantle genuinely needs the
+    # curves, so reject that combination (numpy fallback fails the same
+    # way there).
+    if solidus_func is None or liquidus_func is None:
+        if not mantle_is_unified:
+            raise ValueError(
+                'JAX path needs solidus/liquidus functions for a PALEOS-2phase mantle'
+            )
+        _nan4 = np.full(4, np.nan)
+        melt_curves = {
+            'melt_log_p_min': 8.0,
+            'melt_dlog_p': 1.0,
+            'melt_n': 4,
+            'log_T_liq_table': _nan4,
+            'log_T_sol_table': _nan4,
+        }
+        _entry = melt_curves
+        _key = None
+    else:
+        _key = (id(solidus_func), id(liquidus_func))
+        _entry = _MELT_TABLE_CACHE.get(_key)
     _melt_cache = _MELT_TABLE_CACHE
-    _key = (id(solidus_func), id(liquidus_func))
-    _entry = _melt_cache.get(_key)
     if _entry is None:
         n_melt = 256
         log_p_axis = np.linspace(np.log10(1e8), np.log10(5e12), n_melt)
@@ -437,8 +485,17 @@ def solve_structure_via_jax(
     }
     jax_args.update(_extract_sub_args(core_cached, 'core'))
     jax_args.update(_extract_liquidus(core_cached, 'core'))
-    jax_args.update(_extract_sub_args(sol_cached, 'sol'))
-    jax_args.update(_extract_sub_args(liq_cached, 'liq'))
+    if mantle_is_unified:
+        from ..mixing import _get_mushy_zone_factor
+
+        jax_args.update(_extract_sub_args(mantle_cached, 'mun'))
+        jax_args.update(_extract_liquidus(mantle_cached, 'mun'))
+        jax_args['mushy_zone_factor_mantle'] = float(
+            _get_mushy_zone_factor(mantle_eos, mushy_zone_factors)
+        )
+    else:
+        jax_args.update(_extract_sub_args(sol_cached, 'sol'))
+        jax_args.update(_extract_sub_args(liq_cached, 'liq'))
     jax_args.update(melt_curves)
 
     has_volatile = vol_cached is not None
@@ -491,6 +548,7 @@ def solve_structure_via_jax(
         atol=float(absolute_tolerance),
         T_axis_is_radius=T_axis_is_radius,
         has_volatile=has_volatile,
+        mantle_is_unified=mantle_is_unified,
         **jax_args,
     )
     # np.asarray on a jnp.ndarray yields a read-only view of the JAX

--- a/src/zalmoxis/jax_eos/wrapper.py
+++ b/src/zalmoxis/jax_eos/wrapper.py
@@ -139,7 +139,23 @@ def _validate_wet_mantle(volatile_profile, mantle_lm, material_dictionaries):
     if getattr(volatile_profile, 'x_interior', None):
         raise ValueError('JAX wet path does not support x_interior profiles')
 
-    managed = set(volatile_profile.w_liquid) | set(volatile_profile.w_solid)
+    # A profile entry for the primary silicate itself is degenerate
+    # input: numpy's VolatileProfile.blend() adds its weight to the
+    # volatile total and then overwrites its fraction with the
+    # remainder, a double-count this 2-component blend does not (and
+    # should not) replicate. Reject nonzero primary weights so the
+    # numpy fallback preserves that behavior; zero-weight primary
+    # entries contribute nothing in blend() and are tolerated.
+    primary = volatile_profile.primary_component
+    w_l_primary = float(volatile_profile.w_liquid.get(primary, 0.0))
+    w_s_primary = float(volatile_profile.w_solid.get(primary, 0.0))
+    if w_l_primary > 0.0 or w_s_primary > 0.0:
+        raise ValueError(
+            'JAX wet path: the profile carries nonzero weights for its '
+            f'primary component {primary!r}'
+        )
+
+    managed = (set(volatile_profile.w_liquid) | set(volatile_profile.w_solid)) - {primary}
     active = {}
     for key in managed:
         w_l = float(volatile_profile.w_liquid.get(key, 0.0))
@@ -157,7 +173,7 @@ def _validate_wet_mantle(volatile_profile, mantle_lm, material_dictionaries):
     # An unmanaged extra component keeps its fraction on the numpy path,
     # so dropping it here would silently misrepresent the density;
     # reject instead, and the caller falls back to numpy.
-    allowed = managed | {volatile_profile.primary_component}
+    allowed = managed | {primary}
     extras = [c for c in mantle_lm.components if c not in allowed]
     if extras:
         raise ValueError(
@@ -240,7 +256,10 @@ def solve_structure_via_jax(
     # Core cache: paleos_unified (load via _ensure_unified_cache)
     core_lm = layer_mixtures['core']
     core_eos = core_lm.components[0]  # single-component assumption
-    core_mat = material_dictionaries[core_eos]
+    core_mat = material_dictionaries.get(core_eos)
+    if core_mat is None:
+        # Same fallback contract as the mantle guard below.
+        raise ValueError(f'JAX path: no material entry for core {core_eos!r}')
     # Resolve PALEOS-API lazily if needed (matches numpy dispatch)
     from ..eos.dispatch import _is_paleos_api
 
@@ -283,7 +302,11 @@ def solve_structure_via_jax(
                 f'volatile profile, got {mantle_lm.components!r}'
             )
         mantle_eos = mantle_lm.components[0]
-    mantle_mat = material_dictionaries[mantle_eos]
+    mantle_mat = material_dictionaries.get(mantle_eos)
+    if mantle_mat is None:
+        # ValueError, not KeyError: the caller's numpy fallback only
+        # catches ValueError.
+        raise ValueError(f'JAX path: no material entry for mantle {mantle_eos!r}')
     if '_api_resolved' not in mantle_mat:
         if _is_paleos_api(
             mantle_mat

--- a/src/zalmoxis/jax_eos/wrapper.py
+++ b/src/zalmoxis/jax_eos/wrapper.py
@@ -340,7 +340,14 @@ def solve_structure_via_jax(
                 f'JAX wet path requires a paleos_unified volatile, got '
                 f'format {vol_mat.get("format")!r} for {vol_eos!r}'
             )
-        vol_cached = _ensure_unified_cache(vol_mat['eos_file'], interpolation_cache)
+        _vol_file = vol_mat.get('eos_file')
+        if not _vol_file:
+            # Raise ValueError, not KeyError: the caller's numpy
+            # fallback only catches ValueError (mirrors the mantle guard).
+            raise ValueError(
+                f'paleos_unified volatile entry for {vol_eos!r} carries no eos_file'
+            )
+        vol_cached = _ensure_unified_cache(_vol_file, interpolation_cache)
 
     # mushy_zone_factor for the CORE (paleos_unified takes one; mantle uses Tdep
     # which handles its own solid/liquid separately).

--- a/src/zalmoxis/jax_eos/wrapper.py
+++ b/src/zalmoxis/jax_eos/wrapper.py
@@ -139,8 +139,9 @@ def _validate_wet_mantle(volatile_profile, mantle_lm, material_dictionaries):
     if getattr(volatile_profile, 'x_interior', None):
         raise ValueError('JAX wet path does not support x_interior profiles')
 
+    managed = set(volatile_profile.w_liquid) | set(volatile_profile.w_solid)
     active = {}
-    for key in set(volatile_profile.w_liquid) | set(volatile_profile.w_solid):
+    for key in managed:
         w_l = float(volatile_profile.w_liquid.get(key, 0.0))
         w_s = float(volatile_profile.w_solid.get(key, 0.0))
         if (w_l > 0.0 or w_s > 0.0) and key in mantle_lm.components:
@@ -149,6 +150,19 @@ def _validate_wet_mantle(volatile_profile, mantle_lm, material_dictionaries):
         raise ValueError(
             'JAX wet path supports exactly one active volatile in the '
             f'mantle mixture, got {sorted(active) or "none"}'
+        )
+    # Every mixture component must be the primary silicate, the active
+    # volatile, or profile-managed with zero weight in both phases
+    # (which contributes nothing in numpy's apply_to_mixture either).
+    # An unmanaged extra component keeps its fraction on the numpy path,
+    # so dropping it here would silently misrepresent the density;
+    # reject instead, and the caller falls back to numpy.
+    allowed = managed | {volatile_profile.primary_component}
+    extras = [c for c in mantle_lm.components if c not in allowed]
+    if extras:
+        raise ValueError(
+            'JAX wet path: mantle mixture carries components outside the '
+            f'volatile profile: {extras!r}'
         )
     ((vol_eos, scalars),) = active.items()
     if vol_eos == 'Chabrier:H':

--- a/src/zalmoxis/structure_model.py
+++ b/src/zalmoxis/structure_model.py
@@ -261,13 +261,14 @@ def solve_structure(
     """
     # JAX fast path — dispatch to the diffrax-based implementation when
     # requested. Falls back to numpy path on any ValueError (unsupported
-    # config: 3-layer ice, unsupported mixtures, non-PALEOS-2phase
-    # mantle, unsupported volatile profiles, etc.). Logged at warning;
-    # callers observe the same return contract either way. A
-    # volatile_profile is supported when it carries exactly one active
-    # paleos_unified volatile (the phi-blended wet mantle); profiles
-    # outside that envelope (H2 binodal, miscibility, multi-volatile)
-    # raise ValueError inside the wrapper and land on numpy.
+    # config: 3-layer ice, unsupported mixtures, a mantle in neither the
+    # unified nor the 2-phase PALEOS representation, unsupported
+    # volatile profiles, etc.). Logged at warning; callers observe the
+    # same return contract either way. A volatile_profile is supported
+    # when it carries exactly one active paleos_unified volatile (the
+    # phi-blended wet mantle); profiles outside that envelope (H2
+    # binodal, miscibility, multi-volatile) raise ValueError inside the
+    # wrapper and land on numpy.
     if use_jax:
         try:
             from .jax_eos.wrapper import solve_structure_via_jax

--- a/src/zalmoxis/structure_model.py
+++ b/src/zalmoxis/structure_model.py
@@ -261,18 +261,13 @@ def solve_structure(
     """
     # JAX fast path — dispatch to the diffrax-based implementation when
     # requested. Falls back to numpy path on any ValueError (unsupported
-    # config: 3-layer ice, multi-component mixing, non-PALEOS-2phase
-    # mantle, etc.). Logged at debug; callers observe the same return
-    # contract either way.
-    if use_jax and volatile_profile is not None:
-        # Phi-aware mantle blending is not yet wired into the JAX path;
-        # multi-component mantles fall back to numpy anyway, but force
-        # the fallback explicitly so the dispatch is transparent.
-        logger.debug(
-            'volatile_profile is set; JAX fast path is unsupported, '
-            'falling back to numpy structure solver.'
-        )
-        use_jax = False
+    # config: 3-layer ice, unsupported mixtures, non-PALEOS-2phase
+    # mantle, unsupported volatile profiles, etc.). Logged at warning;
+    # callers observe the same return contract either way. A
+    # volatile_profile is supported when it carries exactly one active
+    # paleos_unified volatile (the phi-blended wet mantle); profiles
+    # outside that envelope (H2 binodal, miscibility, multi-volatile)
+    # raise ValueError inside the wrapper and land on numpy.
     if use_jax:
         try:
             from .jax_eos.wrapper import solve_structure_via_jax
@@ -297,6 +292,7 @@ def solve_structure(
                 condensed_rho_min=condensed_rho_min,
                 condensed_rho_scale=condensed_rho_scale,
                 binodal_T_scale=binodal_T_scale,
+                volatile_profile=volatile_profile,
             )
         except ValueError as exc:
             logger.warning(

--- a/tests/test_jax_parity_synthetic.py
+++ b/tests/test_jax_parity_synthetic.py
@@ -1,0 +1,296 @@
+"""Per-PR numerical parity on synthetic unified tables (no EOS files).
+
+The table-based parity tests need the PALEOS tables, which are not in
+the repository, so on a PR runner they skip and the JAX-vs-numpy
+cross-check effectively only runs nightly. These tests fabricate small
+unified tables in memory and inject them into the interpolation cache
+(``_ensure_unified_cache`` early-returns on pre-populated entries), so
+the same cross-implementation check runs on every PR with no data
+dependency: the numpy reference (``eos.paleos.get_paleos_unified_density``
+through ``structure_model.coupled_odes``) against the JAX kernels, on
+the unified-mantle and wet-blend paths this PR adds.
+
+The synthetic density surface is smooth and fully covers the query
+range, so the numpy KDTree NN fallback (not ported to JAX) never
+engages and agreement is expected at rounding level.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytestmark = pytest.mark.unit
+
+# Synthetic table axes: 1e9 to 1e12 Pa, 1e3 to 1e4 K.
+_N_P, _N_T = 8, 8
+_LOG_P = np.linspace(9.0, 12.0, _N_P)
+_LOG_T = np.linspace(3.0, 4.0, _N_T)
+
+
+def _synthetic_unified_cache(rho0, drho_dlogp, drho_dlogt, liq_lo, liq_hi):
+    """A smooth fabricated unified-table cache entry.
+
+    Density is affine in (log P, log T) so bilinear interpolation is
+    exact and any numpy-vs-JAX discrepancy is implementation, not
+    resolution. The liquidus runs from ``liq_lo`` to ``liq_hi`` K across
+    the pressure range, inside the table's T coverage, so the internal
+    mushy branch (mushy_zone_factor < 1) is exercised.
+    """
+    lp, lt = np.meshgrid(_LOG_P, _LOG_T, indexing='ij')
+    grid = rho0 + drho_dlogp * (lp - 9.0) + drho_dlogt * (lt - 3.0)
+    return {
+        'type': 'paleos_unified',
+        'density_grid': grid,
+        'unique_log_p': _LOG_P.copy(),
+        'unique_log_t': _LOG_T.copy(),
+        'logp_min': float(_LOG_P[0]),
+        'logt_min': float(_LOG_T[0]),
+        'dlog_p': float(_LOG_P[1] - _LOG_P[0]),
+        'dlog_t': float(_LOG_T[1] - _LOG_T[0]),
+        'n_p': _N_P,
+        'n_t': _N_T,
+        'p_min': float(10.0 ** _LOG_P[0]),
+        'p_max': float(10.0 ** _LOG_P[-1]),
+        'logt_valid_min': np.full(_N_P, _LOG_T[0]),
+        'logt_valid_max': np.full(_N_P, _LOG_T[-1]),
+        'liquidus_log_p': _LOG_P.copy(),
+        'liquidus_log_t': np.log10(np.linspace(liq_lo, liq_hi, _N_P)),
+        # Never reached (the affine surface has no NaN cells); present
+        # so an unexpected engagement fails loudly instead of KeyError.
+        'density_nn': lambda pt: (_ for _ in ()).throw(
+            AssertionError('NN fallback engaged on a synthetic table')
+        ),
+    }
+
+
+def _synthetic_world():
+    """Materials, caches, curves, and jax_args for a 2-layer synthetic
+    planet: unified core + unified mantle + one unified volatile."""
+    # Real (whitelisted) component names over synthetic tables: numpy's
+    # _get_mushy_zone_factor returns 1.0 for any name outside
+    # _PALEOS_UNIFIED_NAMES regardless of the config dict, and the JAX
+    # wrapper resolves through the same function, so synthetic names
+    # would silently disable the mushy branch on both sides (and a
+    # hand-fed factor on one side would break parity by construction).
+    core_eos, sil_eos, vol_eos = 'PALEOS:iron', 'PALEOS:MgSiO3', 'PALEOS:H2O'
+    caches = {
+        '/synthetic/core.dat': _synthetic_unified_cache(9000.0, 2500.0, -400.0, 3500.0, 8000.0),
+        '/synthetic/sil.dat': _synthetic_unified_cache(4000.0, 1200.0, -300.0, 2000.0, 6000.0),
+        '/synthetic/vol.dat': _synthetic_unified_cache(1200.0, 900.0, -200.0, 1500.0, 4000.0),
+    }
+    mats = {
+        core_eos: {'eos_file': '/synthetic/core.dat', 'format': 'paleos_unified'},
+        sil_eos: {'eos_file': '/synthetic/sil.dat', 'format': 'paleos_unified'},
+        vol_eos: {'eos_file': '/synthetic/vol.dat', 'format': 'paleos_unified'},
+    }
+    interp_cache = dict(caches)  # pre-populated: _ensure_unified_cache early-returns
+
+    # Analytic external melting curves (wet phi only), inside the T
+    # range. Power-law form on purpose: the RHS consumes these through a
+    # log-log tabulation that is bit-exact for T = A * P^B, so the
+    # tabulation contributes nothing to the parity budget (a curve
+    # linear in P would leave ~1e-2 interpolation residue and mask real
+    # discrepancies).
+    def liq_func(P):
+        return 2200.0 * (P / 1e9) ** 0.12
+
+    def sol_func(P):
+        return 0.8 * liq_func(P)
+
+    melt_lp = np.linspace(9.0, 12.0, 256)
+    melt_p = 10.0**melt_lp
+    log_T_liq = np.log10(np.array([liq_func(P) for P in melt_p]))
+    log_T_sol = np.log10(np.array([sol_func(P) for P in melt_p]))
+
+    # P-indexed synthetic adiabat spanning the table's T range.
+    T_grid = np.linspace(9.0, 12.0, 500)
+    T_vals = 1500.0 + 6000.0 * (T_grid - 9.0) / 3.0
+
+    from zalmoxis.constants import G
+    from zalmoxis.mixing import (
+        _COMPONENT_RHO_MIN,
+        _COMPONENT_RHO_SCALE,
+        CONDENSED_RHO_MIN_DEFAULT,
+        CONDENSED_RHO_SCALE_DEFAULT,
+        _get_mushy_zone_factor,
+    )
+
+    def extract(cache, prefix):
+        out = {
+            f'{prefix}_density_grid': cache['density_grid'],
+            f'{prefix}_unique_log_p': cache['unique_log_p'],
+            f'{prefix}_unique_log_t': cache['unique_log_t'],
+            f'{prefix}_logp_min': cache['logp_min'],
+            f'{prefix}_logt_min': cache['logt_min'],
+            f'{prefix}_dlog_p': cache['dlog_p'],
+            f'{prefix}_dlog_t': cache['dlog_t'],
+            f'{prefix}_n_p': cache['n_p'],
+            f'{prefix}_n_t': cache['n_t'],
+            f'{prefix}_p_min': cache['p_min'],
+            f'{prefix}_p_max': cache['p_max'],
+            f'{prefix}_lt_min_per_p': cache['logt_valid_min'],
+            f'{prefix}_lt_max_per_p': cache['logt_valid_max'],
+            f'{prefix}_liquidus_log_p': cache['liquidus_log_p'],
+            f'{prefix}_liquidus_log_t': cache['liquidus_log_t'],
+            f'{prefix}_liquidus_min_log_p': float(cache['liquidus_log_p'][0]),
+            f'{prefix}_liquidus_max_log_p': float(cache['liquidus_log_p'][-1]),
+            f'{prefix}_has_liquidus_f': 1.0,
+        }
+        return out
+
+    cmb_mass = 2.0e24
+    jax_args = {
+        'cmb_mass': cmb_mass,
+        'T_axis_grid': T_grid,
+        'T_values': T_vals,
+        'T_surface': 1500.0,
+        'mushy_zone_factor_core': 1.0,
+        'mushy_zone_factor_mantle': _get_mushy_zone_factor(sil_eos, {sil_eos: 0.8}),
+        'melt_log_p_min': float(melt_lp[0]),
+        'melt_dlog_p': float(melt_lp[1] - melt_lp[0]),
+        'melt_n': 256,
+        'log_T_liq_table': np.ascontiguousarray(log_T_liq),
+        'log_T_sol_table': np.ascontiguousarray(log_T_sol),
+        'G': G,
+        'vol_w_liquid': 0.083,
+        'vol_w_solid': 0.0,
+        'vol_mushy_zone_factor': 1.0,
+        'sil_rho_min': _COMPONENT_RHO_MIN.get(sil_eos, CONDENSED_RHO_MIN_DEFAULT),
+        'sil_rho_scale': _COMPONENT_RHO_SCALE.get(sil_eos, CONDENSED_RHO_SCALE_DEFAULT),
+        'vol_rho_min': _COMPONENT_RHO_MIN.get(vol_eos, CONDENSED_RHO_MIN_DEFAULT),
+        'vol_rho_scale': _COMPONENT_RHO_SCALE.get(vol_eos, CONDENSED_RHO_SCALE_DEFAULT),
+    }
+    jax_args.update(extract(caches['/synthetic/core.dat'], 'core'))
+    # The core kernel takes the liquidus set through the same names but
+    # without the sub-table split; drop the two keys the extract helper
+    # adds that the core call signature does not carry.
+    jax_args.update(extract(caches['/synthetic/sil.dat'], 'mun'))
+    jax_args.update(extract(caches['/synthetic/vol.dat'], 'vol'))
+
+    return {
+        'eos': (core_eos, sil_eos, vol_eos),
+        'mats': mats,
+        'interp_cache': interp_cache,
+        'sol_func': sol_func,
+        'liq_func': liq_func,
+        'mushy_zone_factors': {core_eos: 1.0, sil_eos: 0.8, vol_eos: 1.0},
+        'cmb_mass': cmb_mass,
+        'jax_args': jax_args,
+        'T_grid': T_grid,
+        'T_vals': T_vals,
+    }
+
+
+@pytest.mark.reference_pinned
+def test_unified_kernel_parity_synthetic():
+    """JAX unified kernel matches eos.paleos.get_paleos_unified_density
+    (the numpy reference) on a fabricated table, direct and mushy
+    branches, at rounding level."""
+    from zalmoxis.eos.paleos import get_paleos_unified_density
+    from zalmoxis.jax_eos.paleos import get_paleos_unified_density_jax
+
+    world = _synthetic_world()
+    cache = world['interp_cache']['/synthetic/sil.dat']
+    mat = world['mats'][world['eos'][1]]
+
+    kernel_args = {
+        k.replace('mun_', ''): v for k, v in world['jax_args'].items() if k.startswith('mun_')
+    }
+
+    P_q = np.logspace(9.1, 11.9, 12)
+    T_q = np.linspace(1200.0, 9500.0, 12)
+    n_mushy = 0
+    for P in P_q:
+        for T in T_q:
+            rho_np = get_paleos_unified_density(P, T, mat, 0.8, world['interp_cache'])
+            rho_jx = float(get_paleos_unified_density_jax(P, T, 0.8, **kernel_args))
+            assert rho_np is not None
+            assert rho_jx == pytest.approx(rho_np, rel=1e-12), (P, T)
+            # Count mushy-branch hits so branch coverage is asserted,
+            # not assumed.
+            T_melt = 10.0 ** float(
+                np.interp(np.log10(P), cache['liquidus_log_p'], cache['liquidus_log_t'])
+            )
+            if 0.8 * T_melt < T < T_melt:
+                n_mushy += 1
+    assert n_mushy > 5, f'mushy branch barely exercised: {n_mushy} points'
+
+
+@pytest.mark.reference_pinned
+def test_rhs_parity_synthetic_unified_wet_and_dry():
+    """JAX RHS matches structure_model.coupled_odes (the numpy
+    reference) on the synthetic planet: unified mantle, dry and with
+    the wet volatile blend."""
+    from zalmoxis.jax_eos.rhs import coupled_odes_jax
+    from zalmoxis.mixing import LayerMixture, VolatileProfile
+    from zalmoxis.structure_model import coupled_odes
+
+    world = _synthetic_world()
+    core_eos, sil_eos, vol_eos = world['eos']
+    T_grid, T_vals = world['T_grid'], world['T_vals']
+
+    def numpy_temp(P):
+        return float(np.interp(np.log10(max(P, 1.0)), T_grid, T_vals))
+
+    cases = [
+        (
+            False,
+            None,
+            {'core': LayerMixture([core_eos], [1.0]), 'mantle': LayerMixture([sil_eos], [1.0])},
+        ),
+        (
+            True,
+            VolatileProfile(
+                w_liquid={vol_eos: 0.083},
+                w_solid={vol_eos: 0.0},
+                primary_component=sil_eos,
+            ),
+            {
+                'core': LayerMixture([core_eos], [1.0]),
+                'mantle': LayerMixture([sil_eos, vol_eos], [0.99, 0.01]),
+            },
+        ),
+    ]
+
+    rng = np.random.default_rng(823)
+    M_planet = 6.0e24
+    for has_volatile, profile, layer_mixtures in cases:
+        n_compared = 0
+        for _ in range(60):
+            r = rng.uniform(1e5, 7e6)
+            P = rng.uniform(2e9, 8e11)  # inside the synthetic table
+            y = np.array([rng.uniform(0.0, M_planet), rng.uniform(0.5, 25.0), P])
+            nv = np.asarray(
+                coupled_odes(
+                    r,
+                    y,
+                    world['cmb_mass'],
+                    world['cmb_mass'] + 3.0e24,
+                    layer_mixtures,
+                    world['interp_cache'],
+                    world['mats'],
+                    numpy_temp(P),
+                    world['sol_func'],
+                    world['liq_func'],
+                    world['mushy_zone_factors'],
+                    volatile_profile=profile,
+                ),
+                dtype=float,
+            )
+            jv = np.asarray(
+                coupled_odes_jax(
+                    r,
+                    y,
+                    has_volatile=has_volatile,
+                    mantle_is_unified=True,
+                    **world['jax_args'],
+                )
+            )
+            # The synthetic tables fully cover the query range: neither
+            # side may zero a shell here.
+            assert np.abs(nv).max() > 0, (r, P)
+            assert np.abs(jv).max() > 0, (r, P)
+            np.testing.assert_allclose(jv, nv, rtol=1e-10, atol=0.0)
+            n_compared += 1
+        assert n_compared == 60

--- a/tests/test_jax_unified_mantle_parity.py
+++ b/tests/test_jax_unified_mantle_parity.py
@@ -161,7 +161,17 @@ def _compare_rhs(setup, layer_mixtures, mat_dicts, profile, jax_extra, seed, tol
 
     numpy_dydr = np.asarray(numpy_dydr, dtype=float)
     jax_dydr = np.asarray(jax_dydr, dtype=float)
-    both = (np.abs(numpy_dydr).max(axis=1) > 0) & (np.abs(jax_dydr).max(axis=1) > 0)
+    nz_numpy = np.abs(numpy_dydr).max(axis=1) > 0
+    nz_jax = np.abs(jax_dydr).max(axis=1) > 0
+    # Directional mask check: JAX nonzero where numpy zeroed would be a
+    # porting bug (assert none); numpy nonzero where JAX zeroed is the
+    # documented un-ported NN fallback on rare out-of-table queries
+    # (bounded so a silently-zeroed JAX branch still fails loudly).
+    assert int((nz_jax & ~nz_numpy).sum()) == 0, 'JAX nonzero where numpy zeroed'
+    n_nn_rescued = int((nz_numpy & ~nz_jax).sum())
+    print(f'NN-fallback-rescued points (numpy nonzero, JAX zeroed): {n_nn_rescued}')
+    assert n_nn_rescued <= 4, f'too many JAX-zeroed points: {n_nn_rescued}/200'
+    both = nz_numpy & nz_jax
     n_both = int(both.sum())
     assert n_both > 100, f'too few comparable points: {n_both}/200'
     with np.errstate(divide='ignore', invalid='ignore'):
@@ -189,6 +199,27 @@ def test_unified_mantle_dry_parity():
 @pytest.mark.integration
 def test_unified_mantle_wet_parity():
     """Wet unified mantle: the volatile blend composes with the unified kernel."""
+    from zalmoxis.mixing import LayerMixture, VolatileProfile
+
+    setup = _unified_setup(mushy_zone_factor=0.8)
+    jax_extra, vol_mat = _h2o_extra(setup)
+
+    layer_mixtures = {
+        'core': LayerMixture(['PALEOS:iron'], [1.0]),
+        'mantle': LayerMixture(['PALEOS:MgSiO3', 'PALEOS:H2O'], [0.99, 0.01]),
+    }
+    mat_dicts = dict(setup['mat_dicts'])
+    mat_dicts['PALEOS:H2O'] = vol_mat
+    profile = VolatileProfile(
+        w_liquid={'PALEOS:H2O': 0.083},
+        w_solid={'PALEOS:H2O': 0.0},
+        primary_component='PALEOS:MgSiO3',
+    )
+    _compare_rhs(setup, layer_mixtures, mat_dicts, profile, jax_extra, seed=419, tol=1e-5)
+
+
+def _h2o_extra(setup):
+    """Wet jax_extra for a PALEOS:H2O volatile on top of the unified mantle."""
     from zalmoxis.eos.interpolation import _ensure_unified_cache
     from zalmoxis.eos.paleos_api_cache import resolve_registry_entry
     from zalmoxis.mixing import (
@@ -196,18 +227,15 @@ def test_unified_mantle_wet_parity():
         _COMPONENT_RHO_SCALE,
         CONDENSED_RHO_MIN_DEFAULT,
         CONDENSED_RHO_SCALE_DEFAULT,
-        LayerMixture,
-        VolatileProfile,
     )
 
-    setup = _unified_setup(mushy_zone_factor=0.8)
     vol_mat = setup['mat_dicts']['PALEOS:H2O']
     resolve_registry_entry(vol_mat)
     if not os.path.isfile(vol_mat.get('eos_file', '')):
         pytest.skip('H2O EOS file missing')
     vol_cached = _ensure_unified_cache(vol_mat['eos_file'], setup['interp_cache'])
 
-    jax_extra = {
+    extra = {
         'has_volatile': True,
         'vol_w_liquid': 0.083,
         'vol_w_solid': 0.0,
@@ -232,21 +260,52 @@ def test_unified_mantle_wet_parity():
     }
     vlp = np.asarray(vol_cached.get('liquidus_log_p', []), dtype=float)
     vlt = np.asarray(vol_cached.get('liquidus_log_t', []), dtype=float)
-    jax_extra['vol_liquidus_log_p'] = vlp
-    jax_extra['vol_liquidus_log_t'] = vlt
-    jax_extra['vol_liquidus_min_log_p'] = float(vlp[0]) if len(vlp) else 0.0
-    jax_extra['vol_liquidus_max_log_p'] = float(vlp[-1]) if len(vlp) else 0.0
-    jax_extra['vol_has_liquidus_f'] = 1.0 if len(vlp) else 0.0
+    extra['vol_liquidus_log_p'] = vlp
+    extra['vol_liquidus_log_t'] = vlt
+    extra['vol_liquidus_min_log_p'] = float(vlp[0]) if len(vlp) else 0.0
+    extra['vol_liquidus_max_log_p'] = float(vlp[-1]) if len(vlp) else 0.0
+    extra['vol_has_liquidus_f'] = 1.0 if len(vlp) else 0.0
+    return extra, vol_mat
+
+
+@pytest.mark.integration
+def test_unified_wet_parity_without_melting_curves():
+    """The all-unified production default hands the wrapper no external
+    melting curves (the loader returns None; the unified density derives
+    its solidus internally). The wrapper then feeds NaN melt tables and
+    the wet blend's phi collapses to the same 0.5 fallback numpy's
+    compute_melt_fraction returns for None curves. This is the exact
+    path a standalone default-config wet solve takes, so pin the parity
+    on it directly. (A 2-phase mantle cannot reach this regime: its
+    numpy Tdep density itself requires the curves and raises.)"""
+    from zalmoxis.mixing import LayerMixture, VolatileProfile
+
+    setup = _unified_setup(mushy_zone_factor=0.8)
+    jax_extra, vol_mat = _h2o_extra(setup)
+
+    # None curves for numpy; the wrapper's NaN placeholder tables for JAX.
+    setup['sol_func'] = None
+    setup['liq_func'] = None
+    nan4 = np.full(4, np.nan)
+    setup['jax_args'].update(
+        {
+            'melt_log_p_min': 8.0,
+            'melt_dlog_p': 1.0,
+            'melt_n': 4,
+            'log_T_liq_table': nan4,
+            'log_T_sol_table': nan4,
+        }
+    )
 
     layer_mixtures = {
         'core': LayerMixture(['PALEOS:iron'], [1.0]),
         'mantle': LayerMixture(['PALEOS:MgSiO3', 'PALEOS:H2O'], [0.99, 0.01]),
     }
+    mat_dicts = dict(setup['mat_dicts'])
+    mat_dicts['PALEOS:H2O'] = vol_mat
     profile = VolatileProfile(
         w_liquid={'PALEOS:H2O': 0.083},
         w_solid={'PALEOS:H2O': 0.0},
         primary_component='PALEOS:MgSiO3',
     )
-    _compare_rhs(
-        setup, layer_mixtures, setup['mat_dicts'], profile, jax_extra, seed=419, tol=1e-5
-    )
+    _compare_rhs(setup, layer_mixtures, mat_dicts, profile, jax_extra, seed=613, tol=1e-5)

--- a/tests/test_jax_unified_mantle_parity.py
+++ b/tests/test_jax_unified_mantle_parity.py
@@ -184,6 +184,7 @@ def _compare_rhs(setup, layer_mixtures, mat_dicts, profile, jax_extra, seed, tol
 
 
 @pytest.mark.integration
+@pytest.mark.reference_pinned
 def test_unified_mantle_dry_parity():
     """Dry unified mantle: JAX RHS matches numpy, mushy zone included."""
     from zalmoxis.mixing import LayerMixture
@@ -197,6 +198,7 @@ def test_unified_mantle_dry_parity():
 
 
 @pytest.mark.integration
+@pytest.mark.reference_pinned
 def test_unified_mantle_wet_parity():
     """Wet unified mantle: the volatile blend composes with the unified kernel."""
     from zalmoxis.mixing import LayerMixture, VolatileProfile
@@ -269,6 +271,7 @@ def _h2o_extra(setup):
 
 
 @pytest.mark.integration
+@pytest.mark.reference_pinned
 def test_unified_wet_parity_without_melting_curves():
     """The all-unified production default hands the wrapper no external
     melting curves (the loader returns None; the unified density derives

--- a/tests/test_jax_unified_mantle_parity.py
+++ b/tests/test_jax_unified_mantle_parity.py
@@ -1,0 +1,252 @@
+"""Parity tests: JAX unified-mantle RHS vs numpy coupled_odes (issue #75).
+
+The production-default mantle (PALEOS:MgSiO3) is a single unified table
+with the solidus derived internally from the table's own liquidus and
+the mushy zone factor. Before the mantle_is_unified port, the JAX
+wrapper rejected it and every default-config solve fell back to numpy.
+These tests compare the JAX RHS against the numpy coupled_odes on that
+representation, dry and wet.
+"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pytest
+
+
+def _unified_setup(mushy_zone_factor=0.8):
+    """Load unified iron core + unified MgSiO3 mantle caches; build jax_args."""
+    from zalmoxis.config import load_material_dictionaries
+    from zalmoxis.eos.interpolation import _ensure_unified_cache
+    from zalmoxis.eos.paleos_api_cache import resolve_registry_entry
+    from zalmoxis.melting_curves import get_solidus_liquidus_functions
+
+    mat_dicts = load_material_dictionaries()
+
+    interp_cache = {}
+    cached = {}
+    for name, key in (('PALEOS:iron', 'core'), ('PALEOS:MgSiO3', 'mun')):
+        mat = mat_dicts[name]
+        resolve_registry_entry(mat)
+        if mat.get('format') != 'paleos_unified':
+            pytest.skip(f'expected paleos_unified {name}, got {mat.get("format")}')
+        if not os.path.isfile(mat['eos_file']):
+            pytest.skip(f'EOS file missing: {mat["eos_file"]}')
+        cached[key] = _ensure_unified_cache(mat['eos_file'], interp_cache)
+
+    # External melting curves are only consumed by the wet blend's phi
+    # (the unified density derives its solidus internally); any
+    # (solidus, liquidus) pair works for parity since both sides get
+    # the same functions.
+    sol_func, liq_func = get_solidus_liquidus_functions()
+
+    def extract_args(c, prefix):
+        return {
+            f'{prefix}_density_grid': np.asarray(c['density_grid']),
+            f'{prefix}_unique_log_p': np.asarray(c['unique_log_p']),
+            f'{prefix}_unique_log_t': np.asarray(c['unique_log_t']),
+            f'{prefix}_logp_min': float(c['logp_min']),
+            f'{prefix}_logt_min': float(c['logt_min']),
+            f'{prefix}_dlog_p': float(c['dlog_p']),
+            f'{prefix}_dlog_t': float(c['dlog_t']),
+            f'{prefix}_n_p': int(c['n_p']),
+            f'{prefix}_n_t': int(c['n_t']),
+            f'{prefix}_p_min': float(c['p_min']),
+            f'{prefix}_p_max': float(c['p_max']),
+            f'{prefix}_lt_min_per_p': np.asarray(c['logt_valid_min']),
+            f'{prefix}_lt_max_per_p': np.asarray(c['logt_valid_max']),
+        }
+
+    def extract_liquidus(c, prefix):
+        lp = np.asarray(c.get('liquidus_log_p', []), dtype=float)
+        lt = np.asarray(c.get('liquidus_log_t', []), dtype=float)
+        return {
+            f'{prefix}_liquidus_log_p': lp,
+            f'{prefix}_liquidus_log_t': lt,
+            f'{prefix}_liquidus_min_log_p': float(lp[0]) if len(lp) else 0.0,
+            f'{prefix}_liquidus_max_log_p': float(lp[-1]) if len(lp) else 0.0,
+            f'{prefix}_has_liquidus_f': 1.0 if len(lp) else 0.0,
+        }
+
+    # External melting curves on the shared log-P axis (wet blend only;
+    # the unified density derives its own solidus internally).
+    melt_lp = np.linspace(np.log10(1e8), np.log10(5e12), 256)
+    melt_p = 10.0**melt_lp
+    log_T_liq = np.log10(np.array([float(liq_func(P)) for P in melt_p]))
+    log_T_sol = np.log10(np.array([float(sol_func(P)) for P in melt_p]))
+
+    T_logP_grid = np.linspace(5.0, 12.5, 2000)
+    T_values = 3000.0 + 5000.0 * (T_logP_grid - 5.0) / (12.5 - 5.0)
+
+    from zalmoxis.constants import G
+
+    cmb_mass = 0.325 * 5.972e24
+    jax_args = {
+        'cmb_mass': float(cmb_mass),
+        'T_axis_grid': T_logP_grid,
+        'T_values': T_values,
+        'T_surface': 3000.0,
+        'mushy_zone_factor_core': 1.0,
+        'mushy_zone_factor_mantle': float(mushy_zone_factor),
+        'melt_log_p_min': float(melt_lp[0]),
+        'melt_dlog_p': float(melt_lp[1] - melt_lp[0]),
+        'melt_n': int(len(melt_lp)),
+        'log_T_liq_table': np.ascontiguousarray(log_T_liq),
+        'log_T_sol_table': np.ascontiguousarray(log_T_sol),
+        'G': G,
+    }
+    jax_args.update(extract_args(cached['core'], 'core'))
+    jax_args.update(extract_liquidus(cached['core'], 'core'))
+    jax_args.update(extract_args(cached['mun'], 'mun'))
+    jax_args.update(extract_liquidus(cached['mun'], 'mun'))
+
+    return {
+        'mat_dicts': mat_dicts,
+        'interp_cache': interp_cache,
+        'sol_func': sol_func,
+        'liq_func': liq_func,
+        'mushy_zone_factors': {
+            'PALEOS:iron': 1.0,
+            'PALEOS:MgSiO3': mushy_zone_factor,
+            'PALEOS:H2O': 1.0,
+        },
+        'cmb_mass': cmb_mass,
+        'jax_args': jax_args,
+        'T_axis_grid': T_logP_grid,
+        'T_values': T_values,
+    }
+
+
+def _compare_rhs(setup, layer_mixtures, mat_dicts, profile, jax_extra, seed, tol):
+    from zalmoxis.jax_eos.rhs import coupled_odes_jax
+    from zalmoxis.structure_model import coupled_odes
+
+    T_logP_grid = setup['T_axis_grid']
+    T_values = setup['T_values']
+
+    def numpy_temp(P):
+        if P <= 0:
+            return 3000.0
+        return float(np.interp(np.log10(max(P, 1.0)), T_logP_grid, T_values))
+
+    rng = np.random.default_rng(seed)
+    M_planet = 5.972e24
+    cmb_mass = setup['cmb_mass']
+
+    numpy_dydr, jax_dydr = [], []
+    for _ in range(200):
+        r = rng.uniform(1e5, 6.4e6)
+        y = np.array(
+            [rng.uniform(0.0, M_planet), rng.uniform(0.5, 25.0), rng.uniform(1e6, 3e11)]
+        )
+        nv = coupled_odes(
+            r,
+            y,
+            cmb_mass,
+            cmb_mass + 0.675 * M_planet,
+            layer_mixtures,
+            setup['interp_cache'],
+            mat_dicts,
+            numpy_temp(y[2]),
+            setup['sol_func'],
+            setup['liq_func'],
+            setup['mushy_zone_factors'],
+            volatile_profile=profile,
+        )
+        numpy_dydr.append(nv)
+        jv = coupled_odes_jax(r, y, mantle_is_unified=True, **jax_extra, **setup['jax_args'])
+        jax_dydr.append(np.asarray(jv))
+
+    numpy_dydr = np.asarray(numpy_dydr, dtype=float)
+    jax_dydr = np.asarray(jax_dydr, dtype=float)
+    both = (np.abs(numpy_dydr).max(axis=1) > 0) & (np.abs(jax_dydr).max(axis=1) > 0)
+    n_both = int(both.sum())
+    assert n_both > 100, f'too few comparable points: {n_both}/200'
+    with np.errstate(divide='ignore', invalid='ignore'):
+        rel = np.abs(numpy_dydr[both] - jax_dydr[both]) / np.maximum(
+            np.abs(numpy_dydr[both]), 1e-30
+        )
+    max_rel = float(rel.max()) if rel.size else 0.0
+    print(f'n_both={n_both}/200, max_rel={max_rel:.3e}')
+    assert max_rel <= tol, f'unified-mantle parity failed: max_rel={max_rel:.3e}'
+
+
+@pytest.mark.integration
+def test_unified_mantle_dry_parity():
+    """Dry unified mantle: JAX RHS matches numpy, mushy zone included."""
+    from zalmoxis.mixing import LayerMixture
+
+    setup = _unified_setup(mushy_zone_factor=0.8)
+    layer_mixtures = {
+        'core': LayerMixture(['PALEOS:iron'], [1.0]),
+        'mantle': LayerMixture(['PALEOS:MgSiO3'], [1.0]),
+    }
+    _compare_rhs(setup, layer_mixtures, setup['mat_dicts'], None, {}, seed=317, tol=1e-6)
+
+
+@pytest.mark.integration
+def test_unified_mantle_wet_parity():
+    """Wet unified mantle: the volatile blend composes with the unified kernel."""
+    from zalmoxis.eos.interpolation import _ensure_unified_cache
+    from zalmoxis.eos.paleos_api_cache import resolve_registry_entry
+    from zalmoxis.mixing import (
+        _COMPONENT_RHO_MIN,
+        _COMPONENT_RHO_SCALE,
+        CONDENSED_RHO_MIN_DEFAULT,
+        CONDENSED_RHO_SCALE_DEFAULT,
+        LayerMixture,
+        VolatileProfile,
+    )
+
+    setup = _unified_setup(mushy_zone_factor=0.8)
+    vol_mat = setup['mat_dicts']['PALEOS:H2O']
+    resolve_registry_entry(vol_mat)
+    if not os.path.isfile(vol_mat.get('eos_file', '')):
+        pytest.skip('H2O EOS file missing')
+    vol_cached = _ensure_unified_cache(vol_mat['eos_file'], setup['interp_cache'])
+
+    jax_extra = {
+        'has_volatile': True,
+        'vol_w_liquid': 0.083,
+        'vol_w_solid': 0.0,
+        'vol_mushy_zone_factor': 1.0,
+        'sil_rho_min': _COMPONENT_RHO_MIN.get('PALEOS:MgSiO3', CONDENSED_RHO_MIN_DEFAULT),
+        'sil_rho_scale': _COMPONENT_RHO_SCALE.get('PALEOS:MgSiO3', CONDENSED_RHO_SCALE_DEFAULT),
+        'vol_rho_min': _COMPONENT_RHO_MIN.get('PALEOS:H2O', CONDENSED_RHO_MIN_DEFAULT),
+        'vol_rho_scale': _COMPONENT_RHO_SCALE.get('PALEOS:H2O', CONDENSED_RHO_SCALE_DEFAULT),
+        'vol_density_grid': np.asarray(vol_cached['density_grid']),
+        'vol_unique_log_p': np.asarray(vol_cached['unique_log_p']),
+        'vol_unique_log_t': np.asarray(vol_cached['unique_log_t']),
+        'vol_logp_min': float(vol_cached['logp_min']),
+        'vol_logt_min': float(vol_cached['logt_min']),
+        'vol_dlog_p': float(vol_cached['dlog_p']),
+        'vol_dlog_t': float(vol_cached['dlog_t']),
+        'vol_n_p': int(vol_cached['n_p']),
+        'vol_n_t': int(vol_cached['n_t']),
+        'vol_p_min': float(vol_cached['p_min']),
+        'vol_p_max': float(vol_cached['p_max']),
+        'vol_lt_min_per_p': np.asarray(vol_cached['logt_valid_min']),
+        'vol_lt_max_per_p': np.asarray(vol_cached['logt_valid_max']),
+    }
+    vlp = np.asarray(vol_cached.get('liquidus_log_p', []), dtype=float)
+    vlt = np.asarray(vol_cached.get('liquidus_log_t', []), dtype=float)
+    jax_extra['vol_liquidus_log_p'] = vlp
+    jax_extra['vol_liquidus_log_t'] = vlt
+    jax_extra['vol_liquidus_min_log_p'] = float(vlp[0]) if len(vlp) else 0.0
+    jax_extra['vol_liquidus_max_log_p'] = float(vlp[-1]) if len(vlp) else 0.0
+    jax_extra['vol_has_liquidus_f'] = 1.0 if len(vlp) else 0.0
+
+    layer_mixtures = {
+        'core': LayerMixture(['PALEOS:iron'], [1.0]),
+        'mantle': LayerMixture(['PALEOS:MgSiO3', 'PALEOS:H2O'], [0.99, 0.01]),
+    }
+    profile = VolatileProfile(
+        w_liquid={'PALEOS:H2O': 0.083},
+        w_solid={'PALEOS:H2O': 0.0},
+        primary_component='PALEOS:MgSiO3',
+    )
+    _compare_rhs(
+        setup, layer_mixtures, setup['mat_dicts'], profile, jax_extra, seed=419, tol=1e-5
+    )

--- a/tests/test_jax_wet_mantle_parity.py
+++ b/tests/test_jax_wet_mantle_parity.py
@@ -296,6 +296,52 @@ def test_wet_mantle_with_unmanaged_component_falls_back():
     assert w_s == 0.0
 
 
+@pytest.mark.unit
+def test_wet_profile_with_weighted_primary_falls_back():
+    """A nonzero profile weight on the primary silicate is degenerate
+    input: numpy's blend() double-counts it into the volatile total
+    before the remainder overwrite, which the 2-component JAX blend
+    does not replicate. Reject to the numpy fallback, which preserves
+    that behavior. Zero-weight primary entries contribute nothing in
+    blend() and stay allowed."""
+    from zalmoxis.jax_eos.wrapper import _validate_wet_mantle
+    from zalmoxis.mixing import LayerMixture, VolatileProfile
+
+    mats = {'PALEOS:H2O': {}}
+    lm = LayerMixture(['PALEOS:MgSiO3', 'PALEOS:H2O'], [0.99, 0.01])
+
+    # Weighted primary alongside a genuine volatile: rejected.
+    p_weighted = VolatileProfile(
+        w_liquid={'PALEOS:MgSiO3': 0.9, 'PALEOS:H2O': 0.05},
+        w_solid={},
+        primary_component='PALEOS:MgSiO3',
+    )
+    with pytest.raises(ValueError, match='nonzero weights for its primary'):
+        _validate_wet_mantle(p_weighted, lm, mats)
+
+    # Weighted primary alone: rejected the same way (numpy would treat
+    # it as pure silicate via the remainder overwrite).
+    p_only = VolatileProfile(
+        w_liquid={'PALEOS:MgSiO3': 0.9},
+        w_solid={},
+        primary_component='PALEOS:MgSiO3',
+    )
+    with pytest.raises(ValueError, match='nonzero weights for its primary'):
+        _validate_wet_mantle(p_only, lm, mats)
+
+    # Zero-weight primary entry: harmless, the real volatile is found.
+    p_zero = VolatileProfile(
+        w_liquid={'PALEOS:MgSiO3': 0.0, 'PALEOS:H2O': 0.05},
+        w_solid={},
+        primary_component='PALEOS:MgSiO3',
+    )
+    vol_eos, (w_l, w_s) = _validate_wet_mantle(p_zero, lm, mats)
+    assert vol_eos == 'PALEOS:H2O'
+    assert w_l == pytest.approx(0.05)
+    # Exact zero is intended: literal passthrough, no arithmetic.
+    assert w_s == 0.0
+
+
 @pytest.mark.integration
 @pytest.mark.physics_invariant
 def test_wet_blend_reduces_to_dry_at_zero_w_liquid():

--- a/tests/test_jax_wet_mantle_parity.py
+++ b/tests/test_jax_wet_mantle_parity.py
@@ -211,14 +211,17 @@ def test_wet_profile_gates_fall_back():
     with pytest.raises(ValueError, match='exactly one active volatile'):
         _validate_wet_mantle(p2, lm, mats)
 
-    # H2 alone: binodal suppression not ported.
+    # H2 alone: binodal suppression not ported. The mixture must match
+    # the profile so the Chabrier-specific gate fires rather than the
+    # unmanaged-component check.
     ph2 = VolatileProfile(
         w_liquid={'Chabrier:H': 0.01},
         w_solid={},
         primary_component='PALEOS:MgSiO3',
     )
+    lm_h2 = LayerMixture(['PALEOS:MgSiO3', 'Chabrier:H'], [0.99, 0.01])
     with pytest.raises(ValueError, match='Chabrier:H'):
-        _validate_wet_mantle(ph2, lm, mats)
+        _validate_wet_mantle(ph2, lm_h2, mats)
 
     # Miscibility profiles stay on numpy.
     pm = VolatileProfile(
@@ -230,9 +233,48 @@ def test_wet_profile_gates_fall_back():
     with pytest.raises(ValueError, match='global_miscibility'):
         _validate_wet_mantle(pm, lm, mats)
 
-    # The supported envelope: one active paleos-table volatile.
+    # The supported envelope: one active paleos-table volatile, and the
+    # mixture carries nothing outside the profile (the 3-component lm
+    # above has an unmanaged Chabrier:H, which is itself rejected; see
+    # test_wet_mantle_with_unmanaged_component_falls_back).
     pm.global_miscibility = False
-    vol_eos, (w_l, w_s) = _validate_wet_mantle(pm, lm, mats)
+    lm_ok = LayerMixture(['PALEOS:MgSiO3', 'PALEOS:H2O'], [0.99, 0.01])
+    vol_eos, (w_l, w_s) = _validate_wet_mantle(pm, lm_ok, mats)
+    assert vol_eos == 'PALEOS:H2O'
+    assert w_l == pytest.approx(0.05)
+    assert w_s == 0.0
+
+
+@pytest.mark.integration
+def test_wet_mantle_with_unmanaged_component_falls_back():
+    """A mixture component outside the profile keeps its fraction on the
+    numpy path (apply_to_mixture), so the 2-component JAX blend would
+    silently drop it; the wrapper must reject it to the numpy fallback.
+    Profile-managed components with zero weight in both phases contribute
+    nothing in numpy and stay allowed."""
+    from zalmoxis.jax_eos.wrapper import _validate_wet_mantle
+    from zalmoxis.mixing import LayerMixture, VolatileProfile
+
+    mats = {'PALEOS:H2O': {}}
+    profile = VolatileProfile(
+        w_liquid={'PALEOS:H2O': 0.05},
+        w_solid={'PALEOS:H2O': 0.0},
+        primary_component='PALEOS:MgSiO3',
+    )
+
+    lm_extra = LayerMixture(['PALEOS:MgSiO3', 'PALEOS:H2O', 'PALEOS:iron'], [0.90, 0.05, 0.05])
+    with pytest.raises(ValueError, match='outside the volatile profile'):
+        _validate_wet_mantle(profile, lm_extra, mats)
+
+    # Managed-but-inactive component: zero weight in both phases blends
+    # to zero in numpy, so the JAX envelope keeps it.
+    profile_managed = VolatileProfile(
+        w_liquid={'PALEOS:H2O': 0.05, 'Chabrier:H': 0.0},
+        w_solid={'PALEOS:H2O': 0.0, 'Chabrier:H': 0.0},
+        primary_component='PALEOS:MgSiO3',
+    )
+    lm_managed = LayerMixture(['PALEOS:MgSiO3', 'PALEOS:H2O', 'Chabrier:H'], [0.90, 0.05, 0.05])
+    vol_eos, (w_l, w_s) = _validate_wet_mantle(profile_managed, lm_managed, mats)
     assert vol_eos == 'PALEOS:H2O'
     assert w_l == pytest.approx(0.05)
     assert w_s == 0.0

--- a/tests/test_jax_wet_mantle_parity.py
+++ b/tests/test_jax_wet_mantle_parity.py
@@ -168,7 +168,20 @@ def test_coupled_odes_jax_wet_parity():
     numpy_dydr = np.asarray(numpy_dydr, dtype=float)
     jax_dydr = np.asarray(jax_dydr, dtype=float)
 
-    both_nonzero = (np.abs(numpy_dydr).max(axis=1) > 0) & (np.abs(jax_dydr).max(axis=1) > 0)
+    nz_numpy = np.abs(numpy_dydr).max(axis=1) > 0
+    nz_jax = np.abs(jax_dydr).max(axis=1) > 0
+    # Directional mask check. JAX producing a derivative where numpy
+    # zeroed the shell would be a porting bug: assert none. The opposite
+    # direction is the documented un-ported numpy KDTree NN fallback
+    # rescuing rare out-of-table (P, T) queries (jax_eos/paleos.py
+    # returns NaN there, zeroing the RHS): tolerate a small count so a
+    # silently-zeroed JAX branch still fails loudly.
+    assert int((nz_jax & ~nz_numpy).sum()) == 0, 'JAX nonzero where numpy zeroed'
+    n_nn_rescued = int((nz_numpy & ~nz_jax).sum())
+    print(f'NN-fallback-rescued points (numpy nonzero, JAX zeroed): {n_nn_rescued}')
+    assert n_nn_rescued <= 4, f'too many JAX-zeroed points: {n_nn_rescued}/200'
+
+    both_nonzero = nz_numpy & nz_jax
     n_both = int(both_nonzero.sum())
     assert n_both > 100, f'too few comparable points: {n_both}/200'
 
@@ -193,7 +206,7 @@ def test_coupled_odes_jax_wet_parity():
     assert max_rel <= 1e-5, f'wet RHS parity failed: max_rel={max_rel:.3e} (want <=1e-5)'
 
 
-@pytest.mark.integration
+@pytest.mark.unit
 def test_wet_profile_gates_fall_back():
     """Unsupported profiles raise ValueError (numpy fallback) in the wrapper."""
     from zalmoxis.jax_eos.wrapper import _validate_wet_mantle
@@ -242,10 +255,12 @@ def test_wet_profile_gates_fall_back():
     vol_eos, (w_l, w_s) = _validate_wet_mantle(pm, lm_ok, mats)
     assert vol_eos == 'PALEOS:H2O'
     assert w_l == pytest.approx(0.05)
+    # Exact zero is intended: the validator passes the 0.0 literal
+    # through with no arithmetic.
     assert w_s == 0.0
 
 
-@pytest.mark.integration
+@pytest.mark.unit
 def test_wet_mantle_with_unmanaged_component_falls_back():
     """A mixture component outside the profile keeps its fraction on the
     numpy path (apply_to_mixture), so the 2-component JAX blend would
@@ -277,4 +292,39 @@ def test_wet_mantle_with_unmanaged_component_falls_back():
     vol_eos, (w_l, w_s) = _validate_wet_mantle(profile_managed, lm_managed, mats)
     assert vol_eos == 'PALEOS:H2O'
     assert w_l == pytest.approx(0.05)
+    # Exact zero is intended: literal passthrough, no arithmetic.
     assert w_s == 0.0
+
+
+@pytest.mark.integration
+@pytest.mark.physics_invariant
+def test_wet_blend_reduces_to_dry_at_zero_w_liquid():
+    """Independent anchor: the parity suite is purely differential, so a
+    bug shared by both implementations would pass. With w_liquid and
+    w_solid at zero the wet blend must reduce to the dry silicate
+    density (the volatile term vanishes and the sigmoid cancels in the
+    single-component harmonic mean), which pins the blend algebra
+    without cross-checking two copies of it."""
+    from zalmoxis.jax_eos.rhs import coupled_odes_jax
+
+    setup = _wet_setup()
+    dry_args = dict(setup['jax_args'])
+    wet_zero_args = dict(setup['jax_args'])
+    wet_zero_args['vol_w_liquid'] = 0.0
+    wet_zero_args['vol_w_solid'] = 0.0
+
+    rng = np.random.default_rng(509)
+    M_planet = 5.972e24
+    n_checked = 0
+    for _ in range(100):
+        r = rng.uniform(1e5, 6.4e6)
+        y = np.array(
+            [rng.uniform(0.0, M_planet), rng.uniform(0.5, 25.0), rng.uniform(1e6, 3e11)]
+        )
+        dv = np.asarray(coupled_odes_jax(r, y, has_volatile=False, **dry_args))
+        wv = np.asarray(coupled_odes_jax(r, y, has_volatile=True, **wet_zero_args))
+        if np.abs(dv).max() == 0.0 and np.abs(wv).max() == 0.0:
+            continue  # both zeroed (out-of-table shell); nothing to compare
+        n_checked += 1
+        np.testing.assert_allclose(wv, dv, rtol=1e-13, atol=0.0)
+    assert n_checked > 50, f'too few comparable points: {n_checked}/100'

--- a/tests/test_jax_wet_mantle_parity.py
+++ b/tests/test_jax_wet_mantle_parity.py
@@ -97,6 +97,7 @@ def _wet_setup():
 
 
 @pytest.mark.integration
+@pytest.mark.reference_pinned
 def test_coupled_odes_jax_wet_parity():
     """JAX wet-mantle RHS matches numpy coupled_odes + VolatileProfile."""
     from zalmoxis.jax_eos.rhs import coupled_odes_jax

--- a/tests/test_jax_wet_mantle_parity.py
+++ b/tests/test_jax_wet_mantle_parity.py
@@ -1,0 +1,238 @@
+"""Parity test: JAX wet-mantle RHS vs numpy coupled_odes with a VolatileProfile.
+
+Extends the Stage-1b parity setup with a PALEOS:H2O volatile blended into
+the mantle through a strong-partition VolatileProfile (w_solid = 0). The
+numpy side goes through calculate_mixed_density's suppressed harmonic
+mean with the profile's phi blend; the JAX side through the
+has_volatile=True variant of coupled_odes_jax. Both consume the same
+bilinear kernels, so agreement is expected at the melt-table tabulation
+level (<= 1e-5 relative).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from test_jax_rhs_parity import _stage1b_setup  # noqa: E402
+
+
+def _wet_setup():
+    setup = _stage1b_setup()
+
+    from zalmoxis.config import load_material_dictionaries
+    from zalmoxis.eos.interpolation import _ensure_unified_cache
+    from zalmoxis.eos.paleos_api_cache import resolve_registry_entry
+
+    mat_dicts = load_material_dictionaries()
+    vol_mat = mat_dicts['PALEOS:H2O']
+    resolve_registry_entry(vol_mat)
+    if vol_mat.get('format') != 'paleos_unified':
+        pytest.skip(f'expected paleos_unified H2O, got {vol_mat.get("format")}')
+    vol_file = vol_mat['eos_file']
+    if not os.path.isfile(vol_file):
+        pytest.skip(f'H2O EOS file missing: {vol_file}')
+    vol_cached = _ensure_unified_cache(vol_file, setup['interp_cache'])
+    setup['vol_mat'] = vol_mat
+
+    # Volatile table args (prefix vol_), same extraction as the core.
+    jax_args = setup['jax_args']
+    jax_args.update(
+        {
+            'vol_density_grid': np.asarray(vol_cached['density_grid']),
+            'vol_unique_log_p': np.asarray(vol_cached['unique_log_p']),
+            'vol_unique_log_t': np.asarray(vol_cached['unique_log_t']),
+            'vol_logp_min': float(vol_cached['logp_min']),
+            'vol_logt_min': float(vol_cached['logt_min']),
+            'vol_dlog_p': float(vol_cached['dlog_p']),
+            'vol_dlog_t': float(vol_cached['dlog_t']),
+            'vol_n_p': int(vol_cached['n_p']),
+            'vol_n_t': int(vol_cached['n_t']),
+            'vol_p_min': float(vol_cached['p_min']),
+            'vol_p_max': float(vol_cached['p_max']),
+            'vol_lt_min_per_p': np.asarray(vol_cached['logt_valid_min']),
+            'vol_lt_max_per_p': np.asarray(vol_cached['logt_valid_max']),
+        }
+    )
+    vol_liq_lp = np.asarray(vol_cached.get('liquidus_log_p', []), dtype=float)
+    vol_liq_lt = np.asarray(vol_cached.get('liquidus_log_t', []), dtype=float)
+    jax_args['vol_liquidus_log_p'] = vol_liq_lp
+    jax_args['vol_liquidus_log_t'] = vol_liq_lt
+    jax_args['vol_liquidus_min_log_p'] = float(vol_liq_lp[0]) if len(vol_liq_lp) else 0.0
+    jax_args['vol_liquidus_max_log_p'] = float(vol_liq_lp[-1]) if len(vol_liq_lp) else 0.0
+    jax_args['vol_has_liquidus_f'] = 1.0 if len(vol_liq_lp) else 0.0
+
+    # Profile scalars and sigmoid constants, resolved exactly as
+    # mixing.calculate_mixed_density does.
+    from zalmoxis.mixing import (
+        _COMPONENT_RHO_MIN,
+        _COMPONENT_RHO_SCALE,
+        CONDENSED_RHO_MIN_DEFAULT,
+        CONDENSED_RHO_SCALE_DEFAULT,
+    )
+
+    w_liq, w_sol = 0.083, 0.0
+    jax_args.update(
+        {
+            'vol_w_liquid': w_liq,
+            'vol_w_solid': w_sol,
+            'vol_mushy_zone_factor': 1.0,
+            'sil_rho_min': _COMPONENT_RHO_MIN.get('PALEOS:MgSiO3', CONDENSED_RHO_MIN_DEFAULT),
+            'sil_rho_scale': _COMPONENT_RHO_SCALE.get(
+                'PALEOS:MgSiO3', CONDENSED_RHO_SCALE_DEFAULT
+            ),
+            'vol_rho_min': _COMPONENT_RHO_MIN.get('PALEOS:H2O', CONDENSED_RHO_MIN_DEFAULT),
+            'vol_rho_scale': _COMPONENT_RHO_SCALE.get(
+                'PALEOS:H2O', CONDENSED_RHO_SCALE_DEFAULT
+            ),
+        }
+    )
+    setup['w_liq'] = w_liq
+    setup['w_sol'] = w_sol
+    return setup
+
+
+@pytest.mark.integration
+def test_coupled_odes_jax_wet_parity():
+    """JAX wet-mantle RHS matches numpy coupled_odes + VolatileProfile."""
+    from zalmoxis.jax_eos.rhs import coupled_odes_jax
+    from zalmoxis.mixing import LayerMixture, VolatileProfile
+    from zalmoxis.structure_model import coupled_odes
+
+    setup = _wet_setup()
+    cfg = setup['config_params']
+    T_logP_grid = setup['T_axis_grid']
+    T_values = setup['T_values']
+
+    core_eos = cfg['layer_eos_config']['core']
+    mantle_eos = cfg['layer_eos_config']['mantle']
+    layer_mixtures = {
+        'core': LayerMixture([core_eos], [1.0]),
+        # Extended wet mixture: placeholder fractions, overridden per
+        # shell by the profile (mirrors extend_mantle_eos_with_volatiles).
+        'mantle': LayerMixture([mantle_eos, 'PALEOS:H2O'], [0.99, 0.01]),
+    }
+    mat_dicts = {
+        core_eos: setup['core_mat'],
+        mantle_eos: setup['mantle_mat'],
+        'PALEOS:H2O': setup['vol_mat'],
+    }
+    profile = VolatileProfile(
+        w_liquid={'PALEOS:H2O': setup['w_liq']},
+        w_solid={'PALEOS:H2O': setup['w_sol']},
+        primary_component=mantle_eos,
+    )
+
+    def numpy_temp(r, P):
+        if P <= 0:
+            return 3000.0
+        return float(np.interp(np.log10(max(P, 1.0)), T_logP_grid, T_values))
+
+    rng = np.random.default_rng(211)
+    M_planet = 5.972e24
+    cmb_mass = setup['cmb_mass']
+
+    numpy_dydr = []
+    jax_dydr = []
+    query_info = []
+    for _ in range(200):
+        r = rng.uniform(1e5, 6.4e6)
+        M = rng.uniform(0.0, M_planet)
+        g = rng.uniform(0.5, 25.0)
+        P = rng.uniform(1e6, 3e11)
+        y = np.array([M, g, P])
+        temperature = numpy_temp(r, P)
+        nv = coupled_odes(
+            r,
+            y,
+            cmb_mass,
+            cmb_mass + 0.675 * M_planet,
+            layer_mixtures,
+            setup['interp_cache'],
+            mat_dicts,
+            temperature,
+            setup['sol_func'],
+            setup['liq_func'],
+            setup['mushy_zone_factors'],
+            volatile_profile=profile,
+        )
+        numpy_dydr.append(nv)
+        jv = coupled_odes_jax(r, y, has_volatile=True, **setup['jax_args'])
+        jax_dydr.append(np.asarray(jv))
+        query_info.append((r, M, g, P, temperature, M < cmb_mass))
+
+    numpy_dydr = np.asarray(numpy_dydr, dtype=float)
+    jax_dydr = np.asarray(jax_dydr, dtype=float)
+
+    both_nonzero = (np.abs(numpy_dydr).max(axis=1) > 0) & (np.abs(jax_dydr).max(axis=1) > 0)
+    n_both = int(both_nonzero.sum())
+    assert n_both > 100, f'too few comparable points: {n_both}/200'
+
+    with np.errstate(divide='ignore', invalid='ignore'):
+        rel = np.abs(numpy_dydr[both_nonzero] - jax_dydr[both_nonzero]) / np.maximum(
+            np.abs(numpy_dydr[both_nonzero]), 1e-30
+        )
+    max_rel = float(rel.max()) if rel.size > 0 else 0.0
+    print(f'n_both={n_both}/200, max_rel={max_rel:.3e}')
+
+    if max_rel > 1e-5:
+        row_max = rel.max(axis=1)
+        worst_idx = int(np.argmax(row_max))
+        orig_i = int(np.where(both_nonzero)[0][worst_idx])
+        r_, M_, g_, P_, T_, is_core = query_info[orig_i]
+        print(
+            f'  worst idx={orig_i}: r={r_:.3e}, M={M_:.3e}, P={P_:.3e}, T={T_:.1f}, core={is_core}'
+        )
+        print(f'    numpy={numpy_dydr[orig_i]}')
+        print(f'    jax  ={jax_dydr[orig_i]}')
+
+    assert max_rel <= 1e-5, f'wet RHS parity failed: max_rel={max_rel:.3e} (want <=1e-5)'
+
+
+@pytest.mark.integration
+def test_wet_profile_gates_fall_back():
+    """Unsupported profiles raise ValueError (numpy fallback) in the wrapper."""
+    from zalmoxis.jax_eos.wrapper import _validate_wet_mantle
+    from zalmoxis.mixing import LayerMixture, VolatileProfile
+
+    lm = LayerMixture(['PALEOS:MgSiO3', 'PALEOS:H2O', 'Chabrier:H'], [0.98, 0.01, 0.01])
+    mats = {'PALEOS:H2O': {}, 'Chabrier:H': {}}
+
+    # Two active volatiles: unsupported.
+    p2 = VolatileProfile(
+        w_liquid={'PALEOS:H2O': 0.05, 'Chabrier:H': 0.01},
+        w_solid={},
+        primary_component='PALEOS:MgSiO3',
+    )
+    with pytest.raises(ValueError, match='exactly one active volatile'):
+        _validate_wet_mantle(p2, lm, mats)
+
+    # H2 alone: binodal suppression not ported.
+    ph2 = VolatileProfile(
+        w_liquid={'Chabrier:H': 0.01},
+        w_solid={},
+        primary_component='PALEOS:MgSiO3',
+    )
+    with pytest.raises(ValueError, match='Chabrier:H'):
+        _validate_wet_mantle(ph2, lm, mats)
+
+    # Miscibility profiles stay on numpy.
+    pm = VolatileProfile(
+        w_liquid={'PALEOS:H2O': 0.05},
+        w_solid={},
+        primary_component='PALEOS:MgSiO3',
+    )
+    pm.global_miscibility = True
+    with pytest.raises(ValueError, match='global_miscibility'):
+        _validate_wet_mantle(pm, lm, mats)
+
+    # The supported envelope: one active paleos-table volatile.
+    pm.global_miscibility = False
+    vol_eos, (w_l, w_s) = _validate_wet_mantle(pm, lm, mats)
+    assert vol_eos == 'PALEOS:H2O'
+    assert w_l == pytest.approx(0.05)
+    assert w_s == 0.0

--- a/tests/test_jax_wrapper_branches.py
+++ b/tests/test_jax_wrapper_branches.py
@@ -81,7 +81,8 @@ def _common_fixtures(*, core_format='paleos_unified', mantle_2phase=True):
             'melted_mantle': {'eos_file': liq_cache_file, 'format': 'paleos_unified'},
         }
     else:
-        mantle_mat = {'format': 'paleos_unified', '_api_resolved': True}
+        # Neither supported representation: not unified, no sub-tables.
+        mantle_mat = {'format': 'seager', '_api_resolved': True}
 
     material_dictionaries = {core_eos: core_mat, mantle_eos: mantle_mat}
     interpolation_cache = {
@@ -130,12 +131,36 @@ class TestCoreFormatValidation:
 
 
 class TestMantleFormatValidation:
-    """Mantle must be PALEOS-2phase (solid_mantle + melted_mantle keys)."""
+    """Mantle must be paleos_unified or PALEOS-2phase (sub-table keys)."""
 
-    def test_non_2phase_mantle_raises(self):
+    def test_unsupported_mantle_format_raises(self):
         layer_mixtures, mds, cache = _common_fixtures(mantle_2phase=False)
         radii = np.linspace(1.0, 1e6, 20)
         with pytest.raises(ValueError, match='PALEOS-2phase'):
+            jw.solve_structure_via_jax(
+                layer_mixtures=layer_mixtures,
+                cmb_mass=2e23,
+                core_mantle_mass=4e23,
+                radii=radii,
+                adaptive_radial_fraction=0.5,
+                relative_tolerance=1e-6,
+                absolute_tolerance=1e-8,
+                maximum_step=1e5,
+                material_dictionaries=mds,
+                interpolation_cache=cache,
+                y0=[0.0, 0.0, 1e12],
+                solidus_func=_solidus_func,
+                liquidus_func=_liquidus_func,
+                temperature_function=_t_func,
+            )
+
+    def test_unified_mantle_without_eos_file_raises(self):
+        """A malformed unified entry raises ValueError (numpy fallback),
+        not KeyError, which the caller's except clause would miss."""
+        layer_mixtures, mds, cache = _common_fixtures(mantle_2phase=False)
+        mds['PALEOS-2phase:MgSiO3'] = {'format': 'paleos_unified', '_api_resolved': True}
+        radii = np.linspace(1.0, 1e6, 20)
+        with pytest.raises(ValueError, match='no eos_file'):
             jw.solve_structure_via_jax(
                 layer_mixtures=layer_mixtures,
                 cmb_mass=2e23,

--- a/tests/test_jax_wrapper_branches.py
+++ b/tests/test_jax_wrapper_branches.py
@@ -215,6 +215,54 @@ class TestMantleFormatValidation:
             )
 
 
+class TestMissingMaterialEntries:
+    """Missing registry entries raise ValueError (numpy fallback), not KeyError."""
+
+    def test_missing_mantle_material_raises(self):
+        layer_mixtures, mds, cache = _common_fixtures()
+        del mds['PALEOS-2phase:MgSiO3']
+        radii = np.linspace(1.0, 1e6, 20)
+        with pytest.raises(ValueError, match='no material entry for mantle'):
+            jw.solve_structure_via_jax(
+                layer_mixtures=layer_mixtures,
+                cmb_mass=2e23,
+                core_mantle_mass=4e23,
+                radii=radii,
+                adaptive_radial_fraction=0.5,
+                relative_tolerance=1e-6,
+                absolute_tolerance=1e-8,
+                maximum_step=1e5,
+                material_dictionaries=mds,
+                interpolation_cache=cache,
+                y0=[0.0, 0.0, 1e12],
+                solidus_func=_solidus_func,
+                liquidus_func=_liquidus_func,
+                temperature_function=_t_func,
+            )
+
+    def test_missing_core_material_raises(self):
+        layer_mixtures, mds, cache = _common_fixtures()
+        del mds['PALEOS:iron']
+        radii = np.linspace(1.0, 1e6, 20)
+        with pytest.raises(ValueError, match='no material entry for core'):
+            jw.solve_structure_via_jax(
+                layer_mixtures=layer_mixtures,
+                cmb_mass=2e23,
+                core_mantle_mass=4e23,
+                radii=radii,
+                adaptive_radial_fraction=0.5,
+                relative_tolerance=1e-6,
+                absolute_tolerance=1e-8,
+                maximum_step=1e5,
+                material_dictionaries=mds,
+                interpolation_cache=cache,
+                y0=[0.0, 0.0, 1e12],
+                solidus_func=_solidus_func,
+                liquidus_func=_liquidus_func,
+                temperature_function=_t_func,
+            )
+
+
 class TestTemperatureArraysValidation:
     """``temperature_arrays`` must be two 1-D arrays of equal length."""
 

--- a/tests/test_jax_wrapper_branches.py
+++ b/tests/test_jax_wrapper_branches.py
@@ -178,6 +178,42 @@ class TestMantleFormatValidation:
                 temperature_function=_t_func,
             )
 
+    def test_volatile_without_eos_file_raises(self):
+        """The volatile branch mirrors the mantle guard: a resolved but
+        incomplete paleos_unified volatile entry (format set, eos_file
+        missing) raises ValueError for the numpy fallback, not KeyError."""
+        from zalmoxis.mixing import LayerMixture, VolatileProfile
+
+        layer_mixtures, mds, cache = _common_fixtures()
+        layer_mixtures['mantle'] = LayerMixture(
+            ['PALEOS-2phase:MgSiO3', 'PALEOS:H2O'], [0.99, 0.01]
+        )
+        mds['PALEOS:H2O'] = {'format': 'paleos_unified', '_api_resolved': True}
+        profile = VolatileProfile(
+            w_liquid={'PALEOS:H2O': 0.05},
+            w_solid={'PALEOS:H2O': 0.0},
+            primary_component='PALEOS-2phase:MgSiO3',
+        )
+        radii = np.linspace(1.0, 1e6, 20)
+        with pytest.raises(ValueError, match='no eos_file'):
+            jw.solve_structure_via_jax(
+                layer_mixtures=layer_mixtures,
+                cmb_mass=2e23,
+                core_mantle_mass=4e23,
+                radii=radii,
+                adaptive_radial_fraction=0.5,
+                relative_tolerance=1e-6,
+                absolute_tolerance=1e-8,
+                maximum_step=1e5,
+                material_dictionaries=mds,
+                interpolation_cache=cache,
+                y0=[0.0, 0.0, 1e12],
+                solidus_func=_solidus_func,
+                liquidus_func=_liquidus_func,
+                temperature_function=_t_func,
+                volatile_profile=profile,
+            )
+
 
 class TestTemperatureArraysValidation:
     """``temperature_arrays`` must be two 1-D arrays of equal length."""

--- a/tools/benchmarks/bench_wet_mantle.py
+++ b/tools/benchmarks/bench_wet_mantle.py
@@ -56,6 +56,15 @@ def run(config_path, w_liquid, num_levels, use_jax):
         config_params.get('rock_solidus', 'Stixrude14-solidus'),
         config_params.get('rock_liquidus', 'Stixrude14-liquidus'),
     )
+    if melt_funcs is None:
+        # All-unified configs need no external curves for density, but
+        # the wet blend's phi does; build the defaults, as PROTEUS does.
+        from zalmoxis.melting_curves import get_solidus_liquidus_functions
+
+        melt_funcs = get_solidus_liquidus_functions(
+            config_params.get('rock_solidus', 'Stixrude14-solidus'),
+            config_params.get('rock_liquidus', 'Stixrude14-liquidus'),
+        )
 
     t0 = time.perf_counter()
     results = main(

--- a/tools/benchmarks/bench_wet_mantle.py
+++ b/tools/benchmarks/bench_wet_mantle.py
@@ -85,8 +85,11 @@ def cli(argv=None):
     ap.add_argument('--num-levels', type=int, default=0)
     args = ap.parse_args(argv)
 
+    import zalmoxis.jax_eos.wrapper as jax_wrapper
+
     rows = []
     for label, use_jax in (('numpy', False), ('jax', True)):
+        calls_before = jax_wrapper._CALL_COUNT
         results, wall = run(args.config, args.w_liquid, args.num_levels, use_jax)
         R = float(results['radii'][-1])
         rows.append((label, wall, R, bool(results['converged'])))
@@ -94,14 +97,23 @@ def cli(argv=None):
             f'[{label:5s}] wall={wall:8.1f} s  R={R:.6e} m  converged={results["converged"]}',
             flush=True,
         )
+        # The JAX path silently falls back to numpy on ValueError; a
+        # mis-scoped config would then compare numpy against numpy and
+        # read as validated. Verify the JAX wrapper actually ran.
+        if use_jax and jax_wrapper._CALL_COUNT == calls_before:
+            print(
+                'ERROR: the JAX leg never reached solve_structure_via_jax '
+                '(silent numpy fallback); comparison is numpy vs numpy.'
+            )
+            return 1
 
     (_, wall_np, R_np, ok_np), (_, wall_jx, R_jx, ok_jx) = rows
-    dR = abs(R_jx / R_np - 1.0)
-    print(f'\nspeedup (numpy/jax wall) = {wall_np / max(wall_jx, 1e-9):.2f}x')
-    print(f'|R_jax/R_numpy - 1|      = {dR:.3e}')
     if not (ok_np and ok_jx):
         print('WARNING: at least one path did not fully converge; times not comparable.')
         return 1
+    dR = abs(R_jx / R_np - 1.0)
+    print(f'\nspeedup (numpy/jax wall) = {wall_np / max(wall_jx, 1e-9):.2f}x')
+    print(f'|R_jax/R_numpy - 1|      = {dR:.3e}')
     return 0
 
 

--- a/tools/benchmarks/bench_wet_mantle.py
+++ b/tools/benchmarks/bench_wet_mantle.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+"""Wet-mantle JAX-vs-numpy bench: wall time and structure agreement.
+
+Runs `zalmoxis.solver.main()` on the reference config with a
+strong-partition VolatileProfile (PALEOS:H2O in the melt, w_solid = 0),
+once on the numpy path and once on the JAX path, and reports wall time,
+planet radius, and the relative radius difference. The JAX wet path is
+the `has_volatile=True` variant of `coupled_odes_jax`; before it existed
+every wet solve forced numpy.
+
+Usage
+-----
+    python -m tools.benchmarks.bench_wet_mantle \
+        --config=tests/data/bench_performance.toml \
+        --w-liquid=0.083 [--num-levels=150]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+
+from zalmoxis.config import (
+    load_material_dictionaries,
+    load_solidus_liquidus_functions,
+    load_zalmoxis_config,
+)
+from zalmoxis.mixing import VolatileProfile
+from zalmoxis.solver import main
+
+
+def run(config_path, w_liquid, num_levels, use_jax):
+    config_params = load_zalmoxis_config(config_path)
+    config_params['use_jax'] = use_jax
+    if num_levels:
+        config_params['num_levels'] = int(num_levels)
+    # Long wall so both paths converge rather than accept timeout solutions.
+    config_params.setdefault('wall_timeout', 3600.0)
+
+    mantle_eos = config_params['layer_eos_config']['mantle']
+    if '+' in mantle_eos:
+        raise SystemExit(f'expected a single-component mantle in the config, got {mantle_eos}')
+    profile = VolatileProfile(
+        w_liquid={'PALEOS:H2O': float(w_liquid)},
+        w_solid={'PALEOS:H2O': 0.0},
+        primary_component=mantle_eos,
+    )
+    # Extend the mantle mixture with the volatile placeholder, as the
+    # PROTEUS wrapper does; the profile overrides fractions per shell.
+    config_params['layer_eos_config']['mantle'] = f'{mantle_eos}:0.9900+PALEOS:H2O:0.0100'
+
+    mat_dicts = load_material_dictionaries()
+    melt_funcs = load_solidus_liquidus_functions(
+        config_params['layer_eos_config'],
+        config_params.get('rock_solidus', 'Stixrude14-solidus'),
+        config_params.get('rock_liquidus', 'Stixrude14-liquidus'),
+    )
+
+    t0 = time.perf_counter()
+    results = main(
+        config_params,
+        mat_dicts,
+        melt_funcs,
+        input_dir='.',
+        volatile_profile=profile,
+    )
+    wall = time.perf_counter() - t0
+    return results, wall
+
+
+def cli(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--config', default='tests/data/bench_performance.toml')
+    ap.add_argument('--w-liquid', type=float, default=0.083)
+    ap.add_argument('--num-levels', type=int, default=0)
+    args = ap.parse_args(argv)
+
+    rows = []
+    for label, use_jax in (('numpy', False), ('jax', True)):
+        results, wall = run(args.config, args.w_liquid, args.num_levels, use_jax)
+        R = float(results['radii'][-1])
+        rows.append((label, wall, R, bool(results['converged'])))
+        print(
+            f'[{label:5s}] wall={wall:8.1f} s  R={R:.6e} m  converged={results["converged"]}',
+            flush=True,
+        )
+
+    (_, wall_np, R_np, ok_np), (_, wall_jx, R_jx, ok_jx) = rows
+    dR = abs(R_jx / R_np - 1.0)
+    print(f'\nspeedup (numpy/jax wall) = {wall_np / max(wall_jx, 1e-9):.2f}x')
+    print(f'|R_jax/R_numpy - 1|      = {dR:.3e}')
+    if not (ok_np and ok_jx):
+        print('WARNING: at least one path did not fully converge; times not comparable.')
+        return 1
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(cli())


### PR DESCRIPTION
## Description

Closes #75.

Removes the two remaining reasons a structure solve falls back from the JAX path to the slower numpy path in production-relevant configurations: a wet mantle (a `VolatileProfile` present) forced numpy unconditionally, and the production-default unified mantle representation (`PALEOS:MgSiO3`, a single table with an internal phase boundary) was rejected by the JAX wrapper, which only accepted the opt-in 2-phase representation. With both lifted, the JAX path engages for the default PROTEUS coupled configuration, dry or wet, and for the 2-phase configuration, dry or wet.

What landed, by commit:

- `e740c4e` — the wet mantle on JAX. `coupled_odes_jax` gains a static `has_volatile` variant that blends one volatile into the silicate density exactly as `mixing.calculate_mixed_density` does with a `VolatileProfile`: the linear lever-rule melt fraction of `compute_melt_fraction` (distinct from the smoothstep inside the Tdep silicate kernel), the phi blend $w(\phi) = \phi w_\mathrm{liquid} + (1 - \phi) w_\mathrm{solid}$ with the silicate as remainder, and the suppressed harmonic mean with the per-component condensed-weight sigmoids. The volatile density reuses the existing `get_paleos_unified_density_jax` kernel, so no new interpolation code. The numpy edge semantics are preserved: a component with zero weight is skipped before its density is consulted, and an active component with an invalid density aborts the shell (zeroed RHS, matching numpy's `None`). The wrapper validates the supported envelope in `_validate_wet_mantle` and raises `ValueError` outside it, so the caller's existing numpy fallback handles unsupported profiles. Also fixes a latent hazard: a multi-component mantle without a profile used to silently take `components[0]` on the JAX path and drop the remaining components' mass; it is now rejected to numpy.
- `370a58e` — the unified mantle on JAX (the #75 fix, approach 2 of the issue). The unified-table kernel already existed for the core, complete with the internal-liquidus mushy zone; a static `mantle_is_unified` flag now routes the mantle density through it with the mantle's `mushy_zone_factor`, and the wrapper dispatches on the material format instead of requiring `solid_mantle`/`melted_mantle` sub-tables. Missing external melting curves, which are legitimate for all-unified configs (the loader returns `None`; the unified density derives its solidus internally), mirror numpy's behavior for the wet blend's $\phi$ (the 0.5 fallback of `compute_melt_fraction`) instead of crashing, while a 2-phase mantle without curves is rejected to numpy. Caveat, faithful to numpy but worth knowing: in that no-curves regime a standalone all-unified wet solve blends the volatile at a constant 0.5 melt weight regardless of temperature, on both paths; PROTEUS-coupled wet runs always supply real curves through their own loader and are unaffected. A malformed unified entry (no `eos_file`) raises `ValueError` rather than `KeyError`, so the numpy fallback catches it.

Key touchpoints: `src/zalmoxis/jax_eos/rhs.py` (the two static flags and the wet blend), `src/zalmoxis/jax_eos/solver.py` (compiled-variant cache keyed by the axis/wet/representation triple), `src/zalmoxis/jax_eos/wrapper.py` (representation dispatch, wet-envelope validation, volatile table extraction, melting-curve fallback), `src/zalmoxis/structure_model.py` (capability-based dispatch replacing the hard wet gate), `tools/benchmarks/bench_wet_mantle.py` (new wet numpy-vs-JAX bench). The dry 2-phase trace is unchanged: both flags are static, so the pre-existing compiled variant is byte-identical.

Supported envelope for the wet path: exactly one active volatile in the mantle mixture, `paleos_unified` format. Explicitly rejected to numpy: `Chabrier:H` (its binodal suppression factor is not ported; that physics belongs to the #64 handoff), more than one active volatile, `global_miscibility`, and `x_interior` profiles.

Out of scope, tracked separately: the $\mathrm{H_2}$ binodal and miscibility physics (#64), and the PROTEUS-side wrapper follow-ups once a release carries this (its temperature-handoff gate currently assumes wet means numpy, and its post-solve density rebuild recomputes with the bare mantle EOS string, which would write a dry density column for a JAX-wet solve).

## Validation of changes

Test configuration: Linux (kernel 6.8), Python 3.12, conda `proteus` environment, branch rebased onto `main` at `029e73e` (26.07.03).

Automated tests (all green locally; full JAX suite 58 passed, 1 pre-existing skip):

- `tests/test_jax_wet_mantle_parity.py` (new): wet RHS parity against numpy `coupled_odes` + `VolatileProfile` on the 2-phase mantle over 200 random states spanning core and mantle, max relative difference $1.5 \times 10^{-8}$ (tolerance $10^{-5}$); plus envelope-gate tests (multi-volatile, `Chabrier:H`, `global_miscibility` all raise).
- `tests/test_jax_unified_mantle_parity.py` (new): unified-mantle RHS parity against numpy, dry with the mushy zone exercised (`mushy_zone_factor = 0.8`) at $1.4 \times 10^{-7}$ and wet at $3.2 \times 10^{-7}$ over 200 random states each.
- `tests/test_jax_wrapper_branches.py`: updated for the representation dispatch (an unsupported mantle format still raises to the numpy fallback) and extended with the malformed-unified-entry case.
- The pre-existing JAX suites (bilinear, paleos, tdep, solver, event termination, temperature arrays, wrapper end-to-end) pass unchanged.

End-to-end bench (`tools/benchmarks/bench_wet_mantle.py`, 1 $M_\oplus$, 8.3 wt% $\mathrm{H_2O}$ in melt, 150 levels, idle machine, one-time JIT compilation included in the JAX wall):

- 2-phase mantle (`tests/data/bench_performance.toml`): numpy 294 s vs JAX 197 s, speedup 1.5×, radii agreeing to $3.6 \times 10^{-3}$ relative.
- Unified mantle (`input/default.toml`, the production default): numpy 352 s vs JAX 211 s, speedup 1.67×, radii agreeing to $3.1 \times 10^{-3}$ relative, both legs converged.

The radius gap of a few times $10^{-3}$ between the two paths is at the scale of the outer loop's acceptance noise (both accepted solutions carry up to about 2% outer mass error) and matches the pre-existing dry full-solve parity tolerance ($10^{-3}$); a tolerance-matched parity pass is recommended before quoting production physics numbers from the JAX wet path. In coupled PROTEUS runs the practical gain should exceed the standalone factor, because the coupled numpy wet path pays the slow external-callable Picard mode that the JAX `temperature_arrays` path avoids, and the JIT compilation amortizes across a run's structure updates.

