### PR TITLE
Read the liquid EOS table for fully molten entropy lookups

### DIFF
--- a/src/zalmoxis/eos_export.py
+++ b/src/zalmoxis/eos_export.py
@@ -1260,13 +1260,13 @@ def compute_surface_entropy(
             # for a single-point lookup.
             T_sol = float(np.asarray(solidus_func(P)).item())
             T_liq = float(np.asarray(liquidus_func(P)).item())
-            # Fully molten: read the liquid table at (P, T), matching
-            # compute_entropy_adiabat and the evolution EOS. The single-phase
-            # table is the solid (or unified) table, which is non-converged
-            # (NaN) at molten temperatures for a 2-phase mantle; without this
-            # branch a molten anchor falls through to that table and trips the
-            # NaN guard below. T_liq >= T_sol keeps the mushy_zone_factor = 1.0
-            # case (collapsed solidus = liquidus) on the liquid table.
+            # Fully molten: read the liquid table at the actual (P, T). The
+            # single-phase table is the solid (or unified) table, which has
+            # no converged cells at molten temperatures for a 2-phase mantle,
+            # so a molten anchor falling through to it returns NaN and trips
+            # the guard below. T_liq >= T_sol uses >= so that collapsed
+            # melting curves (solidus equal to the liquidus, no mushy
+            # interval) still route molten points to the liquid table.
             if s_liquid_interp is not None and T_liq >= T_sol and T >= T_liq:
                 pt = np.array([[np.log10(max(P, 1.0)), np.log10(max(T, 300.0))]])
                 return float(s_liquid_interp(pt).item())
@@ -1391,15 +1391,15 @@ def compute_entropy_adiabat(
         return float(s_interp(pt).item())
 
     def entropy_total(P, T):
-        """Evaluate total entropy, routing each phase region to its table.
+        """Evaluate total entropy, phase-routing molten and mushy points.
 
         With 2-phase PALEOS tables the fully molten region (``T >= T_liq``)
         is read from the liquid table at the actual ``(P, T)``, and the mushy
         zone (``T_sol < T < T_liq``) is the melt-fraction-weighted blend
         S = phi * S_liq(P, T_liq) + (1-phi) * S_sol(P, T_sol) of the phase
-        entropies at the enclosing solidus and liquidus. Without
-        phase-specific tables both regions fall back to the single (unified)
-        table.
+        entropies at the enclosing solidus and liquidus. Subsolidus points,
+        and every point when no phase-specific tables are provided, read the
+        single (unified) table.
         """
         if solidus_func is not None and liquidus_func is not None:
             # Coerce to scalar floats: ``solidus_func`` / ``liquidus_func`` may
@@ -1410,19 +1410,14 @@ def compute_entropy_adiabat(
             # for a single-point lookup.
             T_sol = float(np.asarray(solidus_func(P)).item())
             T_liq = float(np.asarray(liquidus_func(P)).item())
-            # Fully molten: read the liquid table at the actual (P, T). The
-            # mushy branch below and the evolution EOS (Aragog P-T and SPIDER
-            # P-S tables) already source the molten region from the liquid
-            # sub-table, so the adiabat must use the same table for a
-            # consistent entropy scale. The single-phase table is the solid (or
-            # unified) table; the solid table has no converged cells at molten
-            # temperatures and returns NaN there, and a super-liquidus adiabat
-            # is molten at every depth, so its deep points must come from the
-            # liquid table to stay finite and keep the profile isentropic.
-            # T_liq >= T_sol (not >) so the mushy_zone_factor = 1.0 case, where
-            # the solidus collapses onto the liquidus and there is no mushy
-            # interval, still routes molten points here rather than to the
-            # solid table.
+            # Fully molten: read the liquid table at the actual (P, T) so the
+            # molten region sits on the liquid-table entropy scale at every
+            # depth. The single-phase table is the solid (or unified) table;
+            # the solid table has no converged cells at molten temperatures
+            # and returns NaN there, which flattens a super-liquidus adiabat
+            # and breaks isentropy. T_liq >= T_sol uses >= so that collapsed
+            # melting curves (solidus equal to the liquidus, no mushy
+            # interval) still route molten points to the liquid table.
             if s_liquid_interp is not None and T_liq >= T_sol and T >= T_liq:
                 pt = np.array([[np.log10(max(P, 1.0)), np.log10(max(T, 300.0))]])
                 return float(s_liquid_interp(pt).item())

--- a/src/zalmoxis/eos_export.py
+++ b/src/zalmoxis/eos_export.py
@@ -1260,6 +1260,16 @@ def compute_surface_entropy(
             # for a single-point lookup.
             T_sol = float(np.asarray(solidus_func(P)).item())
             T_liq = float(np.asarray(liquidus_func(P)).item())
+            # Fully molten: read the liquid table at (P, T), matching
+            # compute_entropy_adiabat and the evolution EOS. The single-phase
+            # table is the solid (or unified) table, which is non-converged
+            # (NaN) at molten temperatures for a 2-phase mantle; without this
+            # branch a molten anchor falls through to that table and trips the
+            # NaN guard below. T_liq >= T_sol keeps the mushy_zone_factor = 1.0
+            # case (collapsed solidus = liquidus) on the liquid table.
+            if s_liquid_interp is not None and T_liq >= T_sol and T >= T_liq:
+                pt = np.array([[np.log10(max(P, 1.0)), np.log10(max(T, 300.0))]])
+                return float(s_liquid_interp(pt).item())
             if T_sol < T < T_liq and T_liq > T_sol:
                 phi = (T - T_sol) / (T_liq - T_sol)
                 pt_sol = np.array([[np.log10(max(P, 1.0)), np.log10(max(T_sol, 300.0))]])
@@ -1381,11 +1391,15 @@ def compute_entropy_adiabat(
         return float(s_interp(pt).item())
 
     def entropy_total(P, T):
-        """Evaluate total entropy including mixed-phase contribution.
+        """Evaluate total entropy, routing each phase region to its table.
 
-        In the mushy zone, S = phi * S_liq(P, T_liq) + (1-phi) * S_sol(P, T_sol).
-        Uses phase-specific tables when available for clean values at
-        the solidus/liquidus.
+        With 2-phase PALEOS tables the fully molten region (``T >= T_liq``)
+        is read from the liquid table at the actual ``(P, T)``, and the mushy
+        zone (``T_sol < T < T_liq``) is the melt-fraction-weighted blend
+        S = phi * S_liq(P, T_liq) + (1-phi) * S_sol(P, T_sol) of the phase
+        entropies at the enclosing solidus and liquidus. Without
+        phase-specific tables both regions fall back to the single (unified)
+        table.
         """
         if solidus_func is not None and liquidus_func is not None:
             # Coerce to scalar floats: ``solidus_func`` / ``liquidus_func`` may
@@ -1396,6 +1410,22 @@ def compute_entropy_adiabat(
             # for a single-point lookup.
             T_sol = float(np.asarray(solidus_func(P)).item())
             T_liq = float(np.asarray(liquidus_func(P)).item())
+            # Fully molten: read the liquid table at the actual (P, T). The
+            # mushy branch below and the evolution EOS (Aragog P-T and SPIDER
+            # P-S tables) already source the molten region from the liquid
+            # sub-table, so the adiabat must use the same table for a
+            # consistent entropy scale. The single-phase table is the solid (or
+            # unified) table; the solid table has no converged cells at molten
+            # temperatures and returns NaN there, and a super-liquidus adiabat
+            # is molten at every depth, so its deep points must come from the
+            # liquid table to stay finite and keep the profile isentropic.
+            # T_liq >= T_sol (not >) so the mushy_zone_factor = 1.0 case, where
+            # the solidus collapses onto the liquidus and there is no mushy
+            # interval, still routes molten points here rather than to the
+            # solid table.
+            if s_liquid_interp is not None and T_liq >= T_sol and T >= T_liq:
+                pt = np.array([[np.log10(max(P, 1.0)), np.log10(max(T, 300.0))]])
+                return float(s_liquid_interp(pt).item())
             if T_sol < T < T_liq and T_liq > T_sol:
                 phi = (T - T_sol) / (T_liq - T_sol)
                 pt_sol = np.array([[np.log10(max(P, 1.0)), np.log10(max(T_sol, 300.0))]])

--- a/tests/test_eos_export.py
+++ b/tests/test_eos_export.py
@@ -1122,11 +1122,16 @@ class TestComputeSurfaceEntropy:
         ``compute_entropy_adiabat`` and drives the SPIDER entropy-IC cross-check
         and the ``adiabatic_from_cmb`` fallback, both of which anchor at fully
         molten temperatures. For a 2-phase mantle the single-phase table is the
-        solid table, NaN at molten temperatures, so a molten anchor previously
-        fell through to it and tripped the NaN guard (silently disabling the
-        cross-check, or raising in the fallback). The molten branch must return
-        the liquid entropy: the 8% gap from the solid value discriminates the
-        tables, and the result must be finite.
+        solid table, NaN at molten temperatures, so a molten anchor that
+        misses the phase routing falls through to it and trips the NaN guard
+        (silently disabling the cross-check, or raising in the fallback). The
+        molten branch must return the liquid entropy: a mis-routed lookup
+        comes back NaN from the solid table (caught by the finiteness
+        assert), and the 8% liquid/solid gap additionally rejects any finite
+        value on the solid entropy scale. The tolerance is tight (rtol 1e-6)
+        because the fixture entropy is affine in (log10 P, log10 T), which
+        bilinear interpolation on the log-log grid reproduces to float
+        precision, so a systematic sub-percent scaling error is resolvable.
         """
         solid_path, liquid_path = pdep_2phase
         T_surf = 4000.0  # molten at P=1e6 (liquidus 2620 K); solid table NaN here
@@ -1142,7 +1147,7 @@ class TestComputeSurfaceEntropy:
         s_liquid = 1.08 * _s_pdep(1.0e6, T_surf)
         s_solid = _s_pdep(1.0e6, T_surf)
         assert np.isfinite(result['S_target'])
-        np.testing.assert_allclose(result['S_target'], s_liquid, rtol=1e-3)
+        np.testing.assert_allclose(result['S_target'], s_liquid, rtol=1e-6)
         assert abs(result['S_target'] - s_solid) > 0.05 * abs(s_solid)
 
 
@@ -1227,16 +1232,25 @@ class TestComputeEntropyAdiabat:
         liquidus). Without phase routing the deep molten points come back NaN,
         the profile flattens to a constant temperature, and isentropy breaks.
         The liquid table carries s = 1.08x the solid formula, so three things
-        must hold and each fails on the unfixed code:
+        must hold and each fails without the molten branch:
 
-        * the fully molten surface anchor's entropy equals the liquid value,
-          not the solid value 8% below it (table discrimination);
-        * the temperature rises monotonically with depth rather than pinning to
-          the surface value, and the whole profile is finite (no NaN plateau);
-        * every profile point lies on the liquid isentrope, checked by an
-          independent recomputation ``1.08 * s(P, T)`` from the fixture formula
-          (not the returned ``S_profile``, which brentq forces to ``S_target``),
+        * the fully molten surface anchor's entropy equals the liquid value
+          (a mis-routed anchor reads the solid table and comes back NaN; the
+          8% guard additionally rejects any finite solid-scale value);
+        * the temperature rises monotonically with depth rather than pinning
+          to the surface value, and the whole profile is finite (no NaN
+          plateau);
+        * every profile point lies on the liquid isentrope, checked against
+          ``1.08 * s(P, T)`` recomputed from the fixture formula rather than
+          the returned ``S_profile`` (which brentq forces to ``S_target``),
           so a depth-routing regression that reads solid at depth is caught.
+          The liquid table tabulates the same formula, so this verifies
+          routing and isentropy, not interpolation accuracy.
+
+        Tolerances are rtol 1e-6: the fixture entropy is affine in
+        (log10 P, log10 T), which bilinear interpolation on the log-log grid
+        reproduces to float precision, so a systematic sub-percent scaling
+        error is resolvable.
         """
         solid_path, liquid_path = pdep_2phase
         P_surf, P_cmb = 1.0e6, 1.0e9
@@ -1260,8 +1274,8 @@ class TestComputeEntropyAdiabat:
         s_solid = _s_pdep(P_surf, T_surf)  # solid-table value (mis-routed branch)
         # Surface anchor entropy is the liquid value, not the solid value.
         assert np.isfinite(S_target)
-        np.testing.assert_allclose(S_target, s_liquid, rtol=1e-3)
-        assert abs(S_target - s_solid) > 0.05 * abs(s_solid)  # 8% gap discriminates
+        np.testing.assert_allclose(S_target, s_liquid, rtol=1e-6)
+        assert abs(S_target - s_solid) > 0.05 * abs(s_solid)  # rejects solid scale
         # No NaN plateau: finite, and temperature rises with depth (the unfixed
         # code pinned every deep point to T_surf).
         order = np.argsort(P)
@@ -1269,10 +1283,10 @@ class TestComputeEntropyAdiabat:
         assert np.all(np.isfinite(T))
         assert np.all(np.diff(Ts) > 0.0)
         assert Ts[-1] > 1.5 * Ts[0]
-        # Independent check: every point sits on the liquid isentrope. Uses the
-        # fixture entropy formula, so it catches a depth-routing regression that
-        # the tautological S_profile == S_target check cannot.
-        np.testing.assert_allclose(1.08 * _s_pdep(P, T), S_target, rtol=5e-3)
+        # Every point sits on the liquid isentrope: recomputed from the fixture
+        # entropy formula, so it catches a depth-routing regression that the
+        # tautological S_profile == S_target check cannot.
+        np.testing.assert_allclose(1.08 * _s_pdep(P, T), S_target, rtol=1e-6)
 
     @pytest.mark.physics_invariant
     def test_fully_molten_routing_survives_collapsed_mushy_zone(self, pdep_2phase):
@@ -1280,10 +1294,13 @@ class TestComputeEntropyAdiabat:
 
         With the mushy zone collapsed there is no ``T_sol < T < T_liq``
         interval, so a strict ``T_liq > T_sol`` guard on the molten branch
-        would send every molten point to the solid table (NaN) and reproduce
-        the original crash. The branch uses ``T_liq >= T_sol``, so a fully
-        molten adiabat over collapsed curves stays finite, isentropic, and
-        anchored to the liquid table.
+        would send every molten point to the solid table, which is NaN there,
+        and flatten the profile. The branch uses ``T_liq >= T_sol``, so a
+        fully molten adiabat over collapsed curves stays finite, isentropic,
+        and anchored to the liquid table. The pinned contract is the fully
+        molten profile; a collapsed-curve adiabat whose isentrope reaches the
+        melting curve at depth crosses a fusion-entropy discontinuity and is
+        not covered here.
         """
         solid_path, liquid_path = pdep_2phase
         # Collapsed curves: solidus == liquidus everywhere.
@@ -1300,7 +1317,7 @@ class TestComputeEntropyAdiabat:
         )
         T = np.asarray(result['T'])
         assert np.isfinite(result['S_target'])
-        np.testing.assert_allclose(result['S_target'], 1.08 * _s_pdep(1.0e6, 4000.0), rtol=1e-3)
+        np.testing.assert_allclose(result['S_target'], 1.08 * _s_pdep(1.0e6, 4000.0), rtol=1e-6)
         assert np.all(np.isfinite(T))
         # Not a NaN-driven flat plateau: the profile actually deepens.
         assert T[-1] > 1.5 * T[0]

--- a/tests/test_eos_export.py
+++ b/tests/test_eos_export.py
@@ -162,6 +162,72 @@ def melting_curves():
     return solidus_func, liquidus_func
 
 
+def _s_pdep(P, T):
+    """P- and T-dependent synthetic entropy [J/(kg*K)], monotone in T.
+
+    Unlike ``_s``, this depends on pressure, so an isentrope is a genuine
+    ``T(P)`` curve rather than a constant-temperature line. That lets an
+    adiabat test exercise the molten interpolation as a function of depth and
+    supplies an independent reference for the recovered profile entropy.
+    """
+    return 1000.0 * np.log(T / 300.0) - 150.0 * np.log(P / 1.0e6)
+
+
+def _pdep_solidus(P):
+    """Solidus for the P-dependent 2-phase fixture; scalar in, scalar out."""
+    out = 2000.0 + 200.0 * np.log10(np.asarray(P) / 1e5)
+    return float(out) if np.ndim(P) == 0 else out
+
+
+def _pdep_liquidus(P):
+    """Liquidus for the P-dependent 2-phase fixture; scalar in, scalar out."""
+    out = 2400.0 + 220.0 * np.log10(np.asarray(P) / 1e5)
+    return float(out) if np.ndim(P) == 0 else out
+
+
+def _write_pdep_phase_table(path, P_arr, T_arr, s_factor, phase, nan_above=None):
+    """Write a synthetic P-dependent phase table.
+
+    When ``nan_above`` (a callable ``P -> T_cut``) is given, the entropy of
+    every row with ``T > T_cut(P)`` is written as ``nan``, so
+    ``load_paleos_all_properties`` returns a NaN entropy there. This mirrors
+    the real PALEOS solid table, whose entropy is non-converged (NaN) at
+    molten temperatures above the liquidus.
+    """
+    lines = [f'# synthetic P-dependent {phase} table\n']
+    for P in P_arr:
+        for T in T_arr:
+            if nan_above is not None and T > nan_above(P):
+                s_val = 'nan'
+            else:
+                s_val = f'{s_factor * _s_pdep(P, T):.8e}'
+            lines.append(
+                f'{P:.8e} {T:.8e} {4000.0:.8e} {1.0e3 * T:.8e} '
+                f'{s_val} 1200 1100 1e-5 0.3 {phase}\n'
+            )
+    Path(path).write_text(''.join(lines))
+
+
+@pytest.fixture
+def pdep_2phase(tmp_path):
+    """P-dependent solid/liquid tables; solid entropy is NaN above the liquidus.
+
+    The liquid entropy is 1.08x the solid formula and finite throughout; the
+    solid entropy is NaN for ``T > liquidus(P)``, reproducing the real PALEOS
+    solid table's non-converged molten region. A fully molten adiabat over
+    these tables reproduces the NaN plateau on the unfixed code (molten points
+    read the solid table) and a finite, depth-varying profile once molten
+    points are routed to the liquid table.
+    """
+    P_arr = np.logspace(6.0, 9.0, 16)
+    T_arr = np.logspace(3.0, 4.3, 28)
+    solid = tmp_path / 'pdep_solid.dat'
+    liquid = tmp_path / 'pdep_liquid.dat'
+    _write_pdep_phase_table(solid, P_arr, T_arr, 1.0, 'solid', nan_above=_pdep_liquidus)
+    _write_pdep_phase_table(liquid, P_arr, T_arr, 1.08, 'liquid')
+    return solid, liquid
+
+
 # ---------------------------------------------------------------------------
 # load_paleos_all_properties
 # ---------------------------------------------------------------------------
@@ -1048,6 +1114,37 @@ class TestComputeSurfaceEntropy:
         # weighted S_target should be larger than the unified result.
         assert twophase > unified
 
+    @pytest.mark.physics_invariant
+    def test_fully_molten_surface_reads_liquid_table(self, pdep_2phase):
+        """A fully molten surface anchor reads the liquid table instead of raising.
+
+        ``compute_surface_entropy`` shares the phase routing of
+        ``compute_entropy_adiabat`` and drives the SPIDER entropy-IC cross-check
+        and the ``adiabatic_from_cmb`` fallback, both of which anchor at fully
+        molten temperatures. For a 2-phase mantle the single-phase table is the
+        solid table, NaN at molten temperatures, so a molten anchor previously
+        fell through to it and tripped the NaN guard (silently disabling the
+        cross-check, or raising in the fallback). The molten branch must return
+        the liquid entropy: the 8% gap from the solid value discriminates the
+        tables, and the result must be finite.
+        """
+        solid_path, liquid_path = pdep_2phase
+        T_surf = 4000.0  # molten at P=1e6 (liquidus 2620 K); solid table NaN here
+        result = eos_export.compute_surface_entropy(
+            solid_path,
+            T_surface=T_surf,
+            P_surface=1.0e6,
+            solidus_func=_pdep_solidus,
+            liquidus_func=_pdep_liquidus,
+            solid_eos_file=solid_path,
+            liquid_eos_file=liquid_path,
+        )
+        s_liquid = 1.08 * _s_pdep(1.0e6, T_surf)
+        s_solid = _s_pdep(1.0e6, T_surf)
+        assert np.isfinite(result['S_target'])
+        np.testing.assert_allclose(result['S_target'], s_liquid, rtol=1e-3)
+        assert abs(result['S_target'] - s_solid) > 0.05 * abs(s_solid)
+
 
 # ---------------------------------------------------------------------------
 # compute_entropy_adiabat
@@ -1119,3 +1216,91 @@ class TestComputeEntropyAdiabat:
         )
         assert np.all(result['T'] > 0)
         assert np.isfinite(result['S_target'])
+
+    @pytest.mark.physics_invariant
+    def test_fully_molten_adiabat_reads_liquid_table(self, pdep_2phase):
+        """Fully molten adiabat reads the liquid table at every depth: finite, isentropic, depth-varying.
+
+        A super-liquidus initial condition is molten at every depth, yet the
+        single-phase table handed to ``compute_entropy_adiabat`` is the solid
+        table, whose entropy is NaN at molten temperatures (here: NaN above the
+        liquidus). Without phase routing the deep molten points come back NaN,
+        the profile flattens to a constant temperature, and isentropy breaks.
+        The liquid table carries s = 1.08x the solid formula, so three things
+        must hold and each fails on the unfixed code:
+
+        * the fully molten surface anchor's entropy equals the liquid value,
+          not the solid value 8% below it (table discrimination);
+        * the temperature rises monotonically with depth rather than pinning to
+          the surface value, and the whole profile is finite (no NaN plateau);
+        * every profile point lies on the liquid isentrope, checked by an
+          independent recomputation ``1.08 * s(P, T)`` from the fixture formula
+          (not the returned ``S_profile``, which brentq forces to ``S_target``),
+          so a depth-routing regression that reads solid at depth is caught.
+        """
+        solid_path, liquid_path = pdep_2phase
+        P_surf, P_cmb = 1.0e6, 1.0e9
+        # Above liquidus(P_surf)=2620 K and molten all the way to P_cmb.
+        T_surf = 4000.0
+        result = eos_export.compute_entropy_adiabat(
+            solid_path,
+            T_surface=T_surf,
+            P_surface=P_surf,
+            P_cmb=P_cmb,
+            n_points=24,
+            solidus_func=_pdep_solidus,
+            liquidus_func=_pdep_liquidus,
+            solid_eos_file=solid_path,
+            liquid_eos_file=liquid_path,
+        )
+        P = np.asarray(result['P'])
+        T = np.asarray(result['T'])
+        S_target = result['S_target']
+        s_liquid = 1.08 * _s_pdep(P_surf, T_surf)  # liquid-table anchor entropy
+        s_solid = _s_pdep(P_surf, T_surf)  # solid-table value (mis-routed branch)
+        # Surface anchor entropy is the liquid value, not the solid value.
+        assert np.isfinite(S_target)
+        np.testing.assert_allclose(S_target, s_liquid, rtol=1e-3)
+        assert abs(S_target - s_solid) > 0.05 * abs(s_solid)  # 8% gap discriminates
+        # No NaN plateau: finite, and temperature rises with depth (the unfixed
+        # code pinned every deep point to T_surf).
+        order = np.argsort(P)
+        Ts = T[order]
+        assert np.all(np.isfinite(T))
+        assert np.all(np.diff(Ts) > 0.0)
+        assert Ts[-1] > 1.5 * Ts[0]
+        # Independent check: every point sits on the liquid isentrope. Uses the
+        # fixture entropy formula, so it catches a depth-routing regression that
+        # the tautological S_profile == S_target check cannot.
+        np.testing.assert_allclose(1.08 * _s_pdep(P, T), S_target, rtol=5e-3)
+
+    @pytest.mark.physics_invariant
+    def test_fully_molten_routing_survives_collapsed_mushy_zone(self, pdep_2phase):
+        """mushy_zone_factor = 1.0 (solidus == liquidus) still routes molten points to the liquid table.
+
+        With the mushy zone collapsed there is no ``T_sol < T < T_liq``
+        interval, so a strict ``T_liq > T_sol`` guard on the molten branch
+        would send every molten point to the solid table (NaN) and reproduce
+        the original crash. The branch uses ``T_liq >= T_sol``, so a fully
+        molten adiabat over collapsed curves stays finite, isentropic, and
+        anchored to the liquid table.
+        """
+        solid_path, liquid_path = pdep_2phase
+        # Collapsed curves: solidus == liquidus everywhere.
+        result = eos_export.compute_entropy_adiabat(
+            solid_path,
+            T_surface=4000.0,
+            P_surface=1.0e6,
+            P_cmb=1.0e9,
+            n_points=16,
+            solidus_func=_pdep_liquidus,
+            liquidus_func=_pdep_liquidus,
+            solid_eos_file=solid_path,
+            liquid_eos_file=liquid_path,
+        )
+        T = np.asarray(result['T'])
+        assert np.isfinite(result['S_target'])
+        np.testing.assert_allclose(result['S_target'], 1.08 * _s_pdep(1.0e6, 4000.0), rtol=1e-3)
+        assert np.all(np.isfinite(T))
+        # Not a NaN-driven flat plateau: the profile actually deepens.
+        assert T[-1] > 1.5 * T[0]


### PR DESCRIPTION
## Description

The entropy lookups in `compute_entropy_adiabat` and `compute_surface_entropy` only routed the mushy zone to the phase-specific 2-phase EOS tables. The fully molten region (temperature at or above the liquidus) fell through to the single-phase table, which for a 2-phase PALEOS mantle is the solid table. The solid table has no converged cells at molten temperatures and returns NaN there, so a super-liquidus adiabat, which is molten at every depth, came back NaN below a few GPa, flattened the deep profile, and broke isentropy. The `liquidus_super` initial condition then found no valid molten adiabat and raised, so the PROTEUS Earth tutorial (`input/tutorials/tutorial_earth.toml`, `PALEOS-2phase:MgSiO3` mantle, `liquidus_super` temperature mode) failed at the interior structure solve with "no valid molten adiabat found ... The EOS table may not support a molten mantle at this pressure".

Both entropy helpers now read the liquid table at the actual `(P, T)` whenever the point is fully molten and 2-phase tables are provided. The guard uses `T_liq >= T_sol`, so the `mushy_zone_factor = 1.0` case (solidus collapsed onto the liquidus, no mushy interval) also routes molten points to the liquid table rather than the solid one. `compute_surface_entropy` backs the SPIDER entropy initial-condition cross-check and the `adiabatic_from_cmb` fallback, so applying the same routing there keeps both working for their fully molten anchors. Single-phase callers, and callers that do not pass a liquid table, keep their previous behaviour.

Follow-up on cost: correctly tracing the molten adiabat means the surface-temperature scan now runs a full `brentq` inversion at every pressure point instead of bailing on the first NaN, so the one-time Earth initial-condition solve takes on the order of two minutes. This wants optimisation (fewer scan probes, coarser adiabat sampling for the binding-depth search, or a looser `brentq` tolerance), which fits under the initialization entropy-cost work in FormingWorlds/PROTEUS#747. Left as a follow-up so this change stays scoped to the correctness fix.

## Validation of changes

macOS, Python 3.12, proteus conda environment.

* Reproduced the crash on `origin/main` with the Earth tutorial. At the Noack and Lasbleis (2020) fallback `P_cmb = 142 GPa` and surface liquidus 1831 K, the deep molten points were read from the solid table and came back NaN (200/200 bracket-expansion failures), so the super-liquidus scan found no valid adiabat and raised. Confirmed directly that the liquid MgSiO3 table has finite entropy at those `(P, T)` (for example 1.25e4 J/kg/K at 8.8 GPa, 5831 K) where the solid table returns NaN, so the region was mis-routed rather than genuinely uncovered.
* After the fix, `solve_superliquidus_adiabat` completes for the Earth tutorial: surface T 4241 K, CMB T 6524 K (fully molten, hotter with depth), achieved superheat 500.0 K matching the configured `delta_T_super`, and zero entropy drift along the profile.
* Added three unit tests over synthetic 2-phase tables whose liquid entropy is 1.08x the solid formula and whose solid entropy is NaN above the liquidus (mirroring the real table). Each fails on the old code and passes with the fix: a fully molten adiabat stays finite, rises monotonically with depth, and sits on the liquid isentrope (checked by an independent recomputation, not the returned profile); the `mushy_zone_factor = 1.0` collapsed-curve case stays on the liquid table; and `compute_surface_entropy` returns the liquid value at a molten anchor instead of tripping its NaN guard.
* Full Zalmoxis unit tier passes (1119 passed, 57 skipped). `ruff check` and `ruff format --check` are clean on the touched files.

Scope note: `compute_entropy_adiabat` still does not hard-fail on a non-finite surface anchor. The super-liquidus scan already rejects such probes through its own finite check, and `compute_surface_entropy` raises, so no accepted initial condition reaches the callers with a NaN anchor; a defensive raise there is left out to avoid regressing the scan, which relies on out-of-table probes returning invalid rather than raising.

## Checklist

- [x] I have followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate (no user-facing docs describe the fully-molten entropy routing; nothing to update)
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
