### PR TITLE
Remove the stale scipy<1.18 cap; verified against scipy 1.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,11 +29,17 @@ classifiers = [
 ]
 dependencies = [
     "numpy",
-    # Upper bound: scipy 1.18 dropped the vendored scipy._lib.array_api_compat
-    # module that pickled EOS interpolator caches (RegularGridInterpolator,
-    # NearestNDInterpolator) reference, so loading a cache fails to unpickle on
-    # scipy >= 1.18. Lower bound follows the JAX stack, which requires scipy >= 1.14.
-    "scipy>=1.14,<1.18",
+    # scipy 1.18 dropped the vendored scipy._lib.array_api_compat module that
+    # pickled EOS interpolator caches (RegularGridInterpolator,
+    # NearestNDInterpolator) can reference, but that's already handled: a
+    # cache that fails to unpickle for this (or any other) reason hits the
+    # ImportError/AttributeError branch in eos/interpolation.py's
+    # `_ensure_unified_cache` and is transparently rebuilt from the text
+    # table. No import in this codebase reaches into scipy._lib directly, so
+    # there is nothing here that scipy >= 1.18 actually breaks; verified by
+    # running the full test suite against scipy 1.18. Lower bound follows the
+    # JAX stack, which requires scipy >= 1.14.
+    "scipy>=1.14",
     "toml",
     "matplotlib",
     "python-ternary",


### PR DESCRIPTION
## What

Removes the `scipy<1.18` cap added defensively in the dependency list. scipy 1.18 dropped the vendored `scipy._lib.array_api_compat` module, which pickled EOS interpolator caches (`RegularGridInterpolator`, `NearestNDInterpolator`) can reference, so a binary cache pickled by an older scipy build can fail to unpickle under scipy >= 1.18.

## Why this is safe to remove

That failure mode is already fully handled, and already tested:

- `eos/interpolation.py`'s `_ensure_unified_cache` catches exactly this case: a stale binary cache that fails to unpickle (`ModuleNotFoundError`, a subclass of the already-caught `ImportError`) is treated the same as a missing/corrupt cache -- it's rejected, logged, and the entry is rebuilt from the authoritative text table instead of propagating.
- `tests/test_eos_functions.py::TestEnsureUnifiedCache::test_rebuilds_when_cache_references_missing_module` already exercises this exact scenario (a pickle whose `GLOBAL` opcode references a module that no longer exists -- the precise failure shape of a scipy-version-mismatched cache) and passes cleanly under scipy 1.18.0.
- No import in this codebase reaches into `scipy._lib` directly (only comments referenced the vendored path); a plain `from scipy.interpolate import NearestNDInterpolator, RegularGridInterpolator` works fine on 1.18.

## Testing (all against scipy 1.18.0, installed fresh)

- `pytest --collect-only`: 1251/1252 tests collect cleanly. The one remaining collection error (`tests/test_jax_temperature_arrays.py`, `'timeout' not found in markers configuration option`) is pre-existing and unrelated -- `pytest-timeout` isn't declared in the `develop` extras, nothing to do with scipy.
- `test_eos_functions.py`, `test_MR_rocky.py`, `test_Seager_water.py`, `test_seager_branches.py`, `test_binodal.py`, `test_energetics.py`: 138 passed, 2 failed. Both failures are pre-existing `FileNotFoundError`s for external EOS data files that need a network download (`osfclient`/`zenodo-get`), unrelated to scipy.
- `test_rebuilds_when_cache_references_missing_module` specifically: passes.

Fixes #74
